### PR TITLE
add gro dependency and convert to es modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,6 @@ node_modules/
 .env
 
 /__sapper__/
+/build
 
 *.ignore.*
-
-*.js
-!index.json.js

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,15 +7,15 @@
   },
   "files.watcherExclude": {
     "**/.git": true,
-    "**/node_modules/**": true,
-    "__sapper__": true,
-    "src/routes/_data.js": true
+    "**/node_modules": true,
+    "**/__sapper__": true,
+    "**/build": true
   },
   "search.exclude": {
     "**/.git": true,
     "**/node_modules": true,
     "__sapper__": true,
-    "src/routes/_data.js": true,
+    "build": true,
     "package-lock.json": true
   }
 }

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ using [`svelte`](https://github.com/sveltejs/svelte) .
 [`typescript`](https://github.com/microsoft/TypeScript) .
 [`babel`](https://github.com/babel/babel) .
 [`rollup`](https://github.com/rollup/rollup) .
+[`gro`](https://github.com/feltcoop/gro) .
 [`prettier`](https://github.com/prettier/prettier) .
 [`sirv`](https://github.com/lukeed/sirv) .
 [`polka`](https://github.com/lukeed/polka) .

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "felt",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -921,10 +921,80 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@feltcoop/gro": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.1.1.tgz",
+      "integrity": "sha512-qjnrxFhehIAriuslKpCC+AArf5P5vCpXVAMkQcBBY6dwQ1dHV6vaZQXLcE6fk8D0sfL8ooLroNbMe5pINYqlMA==",
+      "dev": true,
+      "requires": {
+        "@rollup/plugin-node-resolve": "^7.1.3",
+        "@rollup/pluginutils": "^3.0.10",
+        "@types/fs-extra": "^8.1.0",
+        "@types/node": "^12.12.38",
+        "@types/source-map-support": "^0.5.1",
+        "cheap-watch": "^1.0.2",
+        "fs-extra": "^9.0.0",
+        "kleur": "^3.0.3",
+        "mri": "^1.1.5",
+        "rollup-plugin-commonjs": "^10.1.0",
+        "source-map-support": "^0.5.16",
+        "sourcemap-codec": "^1.4.8",
+        "terser": "^4.6.13"
+      },
+      "dependencies": {
+        "@rollup/pluginutils": {
+          "version": "3.0.10",
+          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.0.10.tgz",
+          "integrity": "sha512-d44M7t+PjmMrASHbhgpSbVgtL6EFyX7J4mYxwQ/c5eoaE6N2VgCgEcWVzNnwycIloti+/MpwFr8qfw+nRw00sw==",
+          "dev": true,
+          "requires": {
+            "@types/estree": "0.0.39",
+            "estree-walker": "^1.0.1",
+            "picomatch": "^2.2.2"
+          }
+        },
+        "@types/node": {
+          "version": "12.12.39",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.39.tgz",
+          "integrity": "sha512-pADGfwnDkr6zagDwEiCVE4yQrv7XDkoeVa4OfA9Ju/zRTk6YNDLGtQbkdL4/56mCQQCs4AhNrBIag6jrp7ZuOg==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "terser": {
+          "version": "4.6.13",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.13.tgz",
+          "integrity": "sha512-wMvqukYgVpQlymbnNbabVZbtM6PN63AzqexpwJL8tbh/mRT9LE5o+ruVduAGL7D6Fpjl+Q+06U5I9Ul82odAhw==",
+          "dev": true,
+          "requires": {
+            "commander": "^2.20.0",
+            "source-map": "~0.6.1",
+            "source-map-support": "~0.5.12"
+          }
+        }
+      }
+    },
     "@polka/url": {
       "version": "1.0.0-next.11",
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.11.tgz",
       "integrity": "sha512-3NsZsJIA/22P3QUyrEDNA2D133H4j224twJrdipXN38dpnIOzAbUDtOwkcJ5pXmn75w7LSQDjA4tO9dm1XlqlA=="
+    },
+    "@rollup/plugin-node-resolve": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-7.1.3.tgz",
+      "integrity": "sha512-RxtSL3XmdTAE2byxekYLnx+98kEUOrPHF/KRVjLH+DEIHy6kjIw7YINQzn+NXiH/NTrQLAwYs0GWB+csWygA9Q==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.0.8",
+        "@types/resolve": "0.0.8",
+        "builtin-modules": "^3.1.0",
+        "is-module": "^1.0.0",
+        "resolve": "^1.14.2"
+      }
     },
     "@rollup/plugin-replace": {
       "version": "2.3.1",
@@ -1061,6 +1131,15 @@
         "@types/mime": "*"
       }
     },
+    "@types/source-map-support": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@types/source-map-support/-/source-map-support-0.5.1.tgz",
+      "integrity": "sha512-VDqnZe9D2zR19qbeRvwYyHSp7AtUtCkTaRVFQ8wzwH9TXw9kKKq/vBhfEnFEXVupO2M0lBMA9mr/XyQ6gEkUOA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -1078,6 +1157,12 @@
       "requires": {
         "color-convert": "^1.9.0"
       }
+    },
+    "at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true
     },
     "babel-plugin-dynamic-import-node": {
       "version": "2.3.0",
@@ -1175,6 +1260,12 @@
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
       }
+    },
+    "cheap-watch": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cheap-watch/-/cheap-watch-1.0.2.tgz",
+      "integrity": "sha512-jp82t+kZAW+ZVnuYuHZEGZqDaUg28uAyOhC915BcKBSYL55fpTyuJ56cYYXZG0JkCPQT80MjRD6q2KqebaPwCw==",
+      "dev": true
     },
     "clean-css": {
       "version": "4.2.3",
@@ -1388,6 +1479,18 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
+    },
+    "fs-extra": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.0.tgz",
+      "integrity": "sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==",
+      "dev": true,
+      "requires": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^1.0.0"
+      }
     },
     "function-bind": {
       "version": "1.1.1",
@@ -1606,6 +1709,16 @@
         "minimist": "^1.2.0"
       }
     },
+    "jsonfile": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
+      "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^1.0.0"
+      }
+    },
     "kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -1716,6 +1829,12 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+    },
+    "mri": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.5.tgz",
+      "integrity": "sha512-d2RKzMD4JNyHMbnbWnznPaa8vbdlq/4pNZ3IgdaGrVbBhebBsGUUE/6qorTMYNS6TwuH3ilfOlD2bf4Igh8CKg==",
+      "dev": true
     },
     "ms": {
       "version": "2.0.0",
@@ -1864,6 +1983,12 @@
       "requires": {
         "pify": "^3.0.0"
       }
+    },
+    "picomatch": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+      "dev": true
     },
     "pidtree": {
       "version": "0.3.0",
@@ -2019,18 +2144,18 @@
       }
     },
     "rollup": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.3.1.tgz",
-      "integrity": "sha512-BRjzOauORe+R0U0I6SkMTSG22nYmtztR/TaBl0SvbXgc3VAxBDrZoB6HROiK0S5px1pUBnLnjBkbzmVuwC9Q1Q==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.8.2.tgz",
+      "integrity": "sha512-LRzMcB8V1M69pSvf6uCbR+W9OPCy5FuxcIwqioWg5RKidrrqKbzjJF9pEGXceaMVkbptNFZgIVJlUokCU0sfng==",
       "dev": true,
       "requires": {
         "fsevents": "~2.1.2"
       },
       "dependencies": {
         "fsevents": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
-          "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+          "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
           "dev": true,
           "optional": true
         }
@@ -2323,9 +2448,9 @@
       }
     },
     "svelte": {
-      "version": "3.20.1",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.20.1.tgz",
-      "integrity": "sha512-m/dw52BZf+p6KYnyKLErIcGalu4pwJrQbUM7VZriRw6ZlJj1qMAZsLcIWzEB3I0hhdJwkKb7LrrvUIeqmbO92Q==",
+      "version": "3.22.2",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.22.2.tgz",
+      "integrity": "sha512-DxumO0+vvHA6NSc2jtVty08I8lFI43q8P2zX6JxZL8J1kqK5NVjad6TRM/twhnWXC+QScnwkZ15O6X1aTsEKTA==",
       "dev": true
     },
     "terser": {
@@ -2431,6 +2556,12 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz",
       "integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw==",
+      "dev": true
+    },
+    "universalify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+      "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
       "dev": true
     },
     "unpipe": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "dev": "sapper dev --src build --routes build/routes --output build/node_modules/@sapper",
-    "build": "npm run build:ts && sapper build --legacy --src build --routes build/routes --output build/node_modules/@sapper",
+    "build": "npm run build:ts && gro dev --no-watch && sapper build --legacy --src build --routes build/routes --output build/node_modules/@sapper",
     "deploy": "NODE_ENV=production node build/project/deploy/deploy.js",
     "deploy:dry": "DEPLOY_DRY_RUN=1 NODE_ENV=production node build/project/deploy/deploy.js",
     "build:ts": "tsc",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "felt",
   "description": "customizable community tools that feel good 💚",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "license": "ISC",
   "author": {
     "name": "Felt.coop",
@@ -9,10 +9,10 @@
     "url": "https://felt.social"
   },
   "scripts": {
-    "dev": "sapper dev",
-    "build": "npm run build:ts && sapper build --legacy",
-    "deploy": "cp src/project/deploy/deploy.js src/project/deploy/deploy.mjs && NODE_ENV=production node --experimental-modules src/project/deploy/deploy.mjs",
-    "deploy:dry": "cp src/project/deploy/deploy.js src/project/deploy/deploy.mjs && DEPLOY_DRY_RUN=1 NODE_ENV=production node --experimental-modules src/project/deploy/deploy.mjs",
+    "dev": "sapper dev --src build --routes build/routes --output build/node_modules/@sapper",
+    "build": "npm run build:ts && sapper build --legacy --src build --routes build/routes --output build/node_modules/@sapper",
+    "deploy": "NODE_ENV=production node build/project/deploy/deploy.js",
+    "deploy:dry": "DEPLOY_DRY_RUN=1 NODE_ENV=production node build/project/deploy/deploy.js",
     "build:ts": "tsc",
     "ts": "tsc -w",
     "start": "node __sapper__/build",
@@ -33,6 +33,7 @@
     "@babel/plugin-transform-runtime": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
     "@babel/runtime": "^7.0.0",
+    "@feltcoop/gro": "^0.1.1",
     "@rollup/plugin-replace": "^2.3.1",
     "@types/body-parser": "^1.19.0",
     "@types/compression": "^1.7.0",
@@ -42,14 +43,14 @@
     "@types/node": "^12.12.32",
     "npm-run-all": "^4.1.5",
     "prettier": "^1.19.1",
-    "rollup": "^2.3.1",
+    "rollup": "^2.8.2",
     "rollup-plugin-babel": "^4.4.0",
     "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-svelte": "^5.2.0",
     "rollup-plugin-terser": "^5.3.0",
     "sapper": "^0.27.11",
-    "svelte": "^3.20.1",
+    "svelte": "^3.22.2",
     "tslib": "^1.11.1",
     "typescript": "^3.8.3"
   },
@@ -68,6 +69,7 @@
       }
     ]
   },
+  "type": "module",
   "engines": {
     "node": "~14.0"
   }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,8 +3,10 @@ import replace from '@rollup/plugin-replace';
 import commonjs from 'rollup-plugin-commonjs';
 import svelte from 'rollup-plugin-svelte';
 import babel from 'rollup-plugin-babel';
-import { terser } from 'rollup-plugin-terser';
+import {terser} from 'rollup-plugin-terser';
 import config from 'sapper/config/rollup.js';
+import {builtinModules} from 'module';
+
 import pkg from './package.json';
 
 const mode = process.env.NODE_ENV;
@@ -40,7 +42,7 @@ export default {
 
 			legacy &&
 				babel({
-					extensions: ['.js', '.mjs', '.html', '.svelte'],
+					extensions: ['.js', '.html', '.svelte'],
 					runtimeHelpers: true,
 					exclude: ['node_modules/@babel/**'],
 					presets: [
@@ -73,7 +75,7 @@ export default {
 
 	server: {
 		input: config.server.input(),
-		output: config.server.output(),
+		output: {...config.server.output(), format: 'esm'},
 		plugins: [
 			replace({
 				'process.browser': false,
@@ -88,10 +90,7 @@ export default {
 			}),
 			commonjs(),
 		],
-		external: Object.keys(pkg.dependencies).concat(
-			require('module').builtinModules ||
-				Object.keys(process.binding('natives')),
-		),
+		external: Object.keys(pkg.dependencies).concat(builtinModules),
 
 		onwarn,
 	},

--- a/src/dev.task.ts
+++ b/src/dev.task.ts
@@ -11,8 +11,8 @@ import {printPath} from '@feltcoop/gro/dist/utils/print.js';
 /*
 
 This task is part of Felt's work-in-progress build process.
-We currently defer compilation of Svelte, TypeScript, and Tailwind
-to existing build processes using Sapper, `tsc` and `tailwind`, respectively.
+We currently defer compilation of Svelte and TypeScript
+to existing build processes using Rollup and `tsc`.
 
 Eventually, this task will be the sole entrypoint
 for building Felt in development.

--- a/src/dev.task.ts
+++ b/src/dev.task.ts
@@ -27,8 +27,9 @@ const isFileIgnoredByCurrentBuild = (path: string): boolean =>
 
 export const task: Task = {
 	description: 'copies build files that the existing build process misses',
-	run: async ({log}): Promise<void> => {
-		const {init} = watchNodeFs({
+	run: async ({log, args}): Promise<void> => {
+		const watch = args.watch === undefined ? true : args.watch; // TODO declare args
+		const {init, dispose} = watchNodeFs({
 			dir: paths.source,
 			onInit: async paths => {
 				log.trace(`init ${paths.size} paths`);
@@ -67,6 +68,10 @@ export const task: Task = {
 			},
 		});
 		await init;
-		log.info('watching...');
+		if (watch) {
+			log.info('watching...');
+		} else {
+			dispose();
+		}
 	},
 };

--- a/src/dev.task.ts
+++ b/src/dev.task.ts
@@ -1,0 +1,72 @@
+import {Task} from '@feltcoop/gro';
+import {
+	paths,
+	basePathToSourceId,
+	basePathToBuildId,
+} from '@feltcoop/gro/dist/paths.js';
+import {watchNodeFs, WatcherChange} from '@feltcoop/gro/dist/fs/watchNodeFs.js';
+import {copy, remove} from '@feltcoop/gro/dist/fs/nodeFs.js';
+import {printPath} from '@feltcoop/gro/dist/utils/print.js';
+
+/*
+
+This task is part of Felt's work-in-progress build process.
+We currently defer compilation of Svelte, TypeScript, and Tailwind
+to existing build processes using Sapper, `tsc` and `tailwind`, respectively.
+
+Eventually, this task will be the sole entrypoint
+for building Felt in development.
+To bridge the target process and the current one,
+this dev task copies certain files to `build/` in watch mode,
+treating `build/` as the old `src/` in the current build tools.
+
+*/
+
+const isFileIgnoredByCurrentBuild = (path: string): boolean =>
+	path.endsWith('.svelte') || path.endsWith('.html');
+
+export const task: Task = {
+	description: 'copies build files that the existing build process misses',
+	run: async ({log}): Promise<void> => {
+		const {init} = watchNodeFs({
+			dir: paths.source,
+			onInit: async paths => {
+				log.trace(`init ${paths.size} paths`);
+				await Promise.all(
+					Array.from(paths.keys()).map(path => {
+						if (!isFileIgnoredByCurrentBuild(path)) return null;
+						log.trace('copying', printPath(path));
+						return copy(basePathToSourceId(path), basePathToBuildId(path));
+					}),
+				);
+			},
+			onChange: async (change, path, stats) => {
+				switch (change) {
+					case WatcherChange.Create: {
+						if (isFileIgnoredByCurrentBuild(path)) {
+							log.trace('created and copying', printPath(path));
+							await copy(basePathToSourceId(path), basePathToBuildId(path));
+						}
+						break;
+					}
+					case WatcherChange.Update: {
+						if (isFileIgnoredByCurrentBuild(path)) {
+							log.trace('updated and copying', printPath(path));
+							await copy(basePathToSourceId(path), basePathToBuildId(path));
+						}
+						break;
+					}
+					case WatcherChange.Delete: {
+						if (isFileIgnoredByCurrentBuild(path) || stats.isDirectory()) {
+							log.trace('deleted and removing', printPath(path));
+							await remove(basePathToBuildId(path));
+						}
+						break;
+					}
+				}
+			},
+		});
+		await init;
+		log.info('watching...');
+	},
+};

--- a/src/dev.task.ts
+++ b/src/dev.task.ts
@@ -7,6 +7,7 @@ import {
 import {watchNodeFs, WatcherChange} from '@feltcoop/gro/dist/fs/watchNodeFs.js';
 import {copy, remove} from '@feltcoop/gro/dist/fs/nodeFs.js';
 import {printPath} from '@feltcoop/gro/dist/utils/print.js';
+import {UnreachableError} from '@feltcoop/gro/dist/utils/error.js';
 
 /*
 
@@ -63,6 +64,9 @@ export const task: Task = {
 							await remove(basePathToBuildId(path));
 						}
 						break;
+					}
+					default: {
+						throw new UnreachableError(change);
 					}
 				}
 			},

--- a/src/project/setup/README.md
+++ b/src/project/setup/README.md
@@ -69,8 +69,9 @@ before [deploying to a production server](../deploy).
 **5. Run the dev server!**
 
 ```bash
-$ npm run ts # for typescript
-$ npm run dev # open another shell for the dev server
+$ npm run ts # compile typescript - let it finish before continuing
+$ gro dev # eventually this will be the only command
+$ npm run dev # open a third shell (lol TODO) for the sapper dev server
 ```
 
 > TODO wrap these into a single command

--- a/src/routes/[slug]/index.json.ts
+++ b/src/routes/[slug]/index.json.ts
@@ -7,7 +7,7 @@ worlds.forEach(world => {
 	worldsBySlug.set(world.slug, JSON.stringify(world));
 });
 
-export function get(req, res, next) {
+export function get(req: any, res: any) { // TODO types
 	// the `slug` parameter is available because
 	// this file is called [slug].json.js
 	const { slug } = req.params;

--- a/src/routes/blog/[slug]/index.json.ts
+++ b/src/routes/blog/[slug]/index.json.ts
@@ -7,7 +7,7 @@ posts.forEach(post => {
 	postsBySlug.set(post.slug, JSON.stringify(post));
 });
 
-export function get(req, res, next) {
+export function get(req: any, res: any) { // TODO types
 	// the `slug` parameter is available because
 	// this file is called [slug].json.js
 	const { slug } = req.params;

--- a/src/routes/blog/index.json.ts
+++ b/src/routes/blog/index.json.ts
@@ -4,7 +4,7 @@ const { posts } = data;
 
 const contents = JSON.stringify(posts);
 
-export function get(req, res) {
+export function get(_req: any, res: any) { // TODO types
 	res.writeHead(200, {
 		'Content-Type': 'application/json',
 	});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,8 +15,8 @@
     // "allowJs": false, // Allow javascript files to be compiled.
     // "checkJs": false, // Report errors in .js files.
     // "outFile": "./", // Concatenate and emit output to single file.
-    // "outDir": "./", // Redirect output structure to the directory.
-    // "rootDir": "./", // Specify the root directory of input files. Use to control the output directory structure with `--outDir`.
+    "outDir": "./build", // Redirect output structure to the directory.
+    "rootDir": "./src", // Specify the root directory of input files. Use to control the output directory structure with `--outDir`.
     // "project": "", // Compile a project given a valid configuration file.
 
     // Compilation options


### PR DESCRIPTION
This adds Gro as a dependency and converts Felt to use ES modules.

This is a step towards making our build a single command. Here's some of the important parts:

- updates [instructions for dev setup](https://github.com/feltcoop/felt/compare/es-modules?expand=1#diff-3af9cba5a40dc334abf684fdcb2f3fceR72)
- `package.json` now [tells Node it uses ES modules](https://github.com/feltcoop/felt/compare/es-modules?expand=1#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R72)
- Rollup [compiles the server to ES modules](https://github.com/feltcoop/felt/compare/es-modules?expand=1#diff-ff6e5f22a9c7e66987b19c0199636480R78)
- `build/` is where [TypeScript is compiled to](https://github.com/feltcoop/felt/compare/es-modules?expand=1#diff-e5e546dd2eb0351f813d63d1b39dbc48R18), and currently, we just copy Svelte files there as well. Previously, we compiled TS next to the the source files and gitignored them.
- adds [Gro as a dependency](https://github.com/feltcoop/felt/compare/es-modules?expand=1#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R36) and adds a [`gro dev`](https://github.com/feltcoop/felt/compare/es-modules?expand=1#diff-d8a0b2cbc30fd26d55fb0b3f468fafc3) task to copy the Svelte and HTML files (the task file includes some documentation about what it's doing and why)
- [Sapper is pointed](https://github.com/feltcoop/felt/compare/es-modules?expand=1#diff-b9cfc7f2cdf78a7f4b91a753d10865a2L14) to `build/`, not `src/`
