### PR TITLE
add some package metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,18 @@
   "description": "customizable community tools that feel good 💚",
   "version": "0.0.1",
   "license": "ISC",
+  "homepage": "https://felt.dev",
   "author": {
     "name": "Felt.coop",
     "email": "team@felt.social",
     "url": "https://felt.social"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/feltcoop/felt.git"
+  },
+  "bugs": {
+    "url": "https://github.com/feltcoop/felt/issues"
   },
   "scripts": {
     "dev": "sapper dev",


### PR DESCRIPTION
This adds some metadata about the Felt repo. Npm was complaining about the "repository" field in particular.

I think it makes sense to have "homepage" set to [felt.dev](https://felt.dev).