### PR TITLE
use the centralized paths module

### DIFF
--- a/src/paths.ts
+++ b/src/paths.ts
@@ -5,10 +5,14 @@ import {
 } from '@feltcoop/gro/dist/paths.js';
 
 const db = basePathToSourceId('db/');
+const sapper = join(defaultPaths.root, '__sapper__/');
 
 export const paths = {
 	...defaultPaths,
 	db,
 	dbMigrations: join(db, 'migrations/'),
 	dbMigrationStub: join(db, 'helpers/migrationStub.ts'),
+	static: join(defaultPaths.root, 'static/'),
+	sapper,
+	sapperBuild: join(sapper, 'build/'),
 };


### PR DESCRIPTION
This extends the paths added in #12 and uses them in the deploy script. Prettier did some formatting and this also cleans up the deployment command, which previously was built in two steps, but no longer needed to be.

Because of the dependency on #12 I branched from it, and it therefore includes its commit here. I'll fix that when it's merged.