### PR TITLE
fix deploy docs formatting

### DIFF
--- a/src/project/deploy/README.md
+++ b/src/project/deploy/README.md
@@ -41,7 +41,7 @@ TODO: (replacing `felt.dev` in both the config file and path automatically)
 
 There are two ways to build and deploy the server. Either locally or from the machine itself.
 
-To build & deploy from your local machine, follow the [setup](src/project/setup) instructions then:
+To build & deploy from your local machine, follow the [setup](../setup) instructions then:
 
 1. copy src/project/deploy/pm2-app.json to /var/www/felt.dev
 2. run `npm run build` to create the build

--- a/src/project/deploy/README.md
+++ b/src/project/deploy/README.md
@@ -14,13 +14,13 @@ for any cloud Linux VPS provider.
 ### 2. Nginx installation & Server Configuration
 
 - Clone the felt git repository into your server
-```bash
+  ```bash
   git clone https://github.com/feltcoop/felt.git
-```
+  ```
 - Then move into the newly cloned repo and run the initialization script
-```bash
+  ```bash
   ./src/project/deploy/initialize-server.sh
-```
+  ```
 
 This will set up the folder and permissions structures, install dependencies, and overall set you up to build and deploy new versions of felt onto your server.
 
@@ -43,9 +43,9 @@ There are two ways to build and deploy the server. Either locally or from the ma
 
 To build & deploy from your local machine, follow the [setup](src/project/setup) instructions then:
 
-copy src/project/deploy/pm2-app.json to /var/www/felt.dev
-run npm run build to create the build
-run npm run deploy to copy the build /var/www/felt.dev/dist
+1. copy src/project/deploy/pm2-app.json to /var/www/felt.dev
+2. run `npm run build` to create the build
+3. run `npm run deploy` to copy the build /var/www/felt.dev/dist
 
 ```bash
 $ pm2 start /var/www/felt.dev/pm2-app.json


### PR DESCRIPTION
Some instructions were just separated by a newline so they ran together. The second commit fixes a broken link. I also indented some code blocks to match their bullet points.

I've also been using the convention of trying to keep lines in markdown to a max of 80 characters, with some exceptions like links and odd cases. Word wrap in an editor makes long lines readable, but wide editor windows are harder to read, and the diffs can be much worse. I didn't change any of the long lines in this PR. Any thoughts?

On the subject of line lengths, do you like 80? That's Prettier's default. Rust uses 100 (or 99). I'd be down to up it to match Rust but I'm also fine leaving it as is. 80 can feel a bit too constrained and the legacy reasons for keeping it aren't good AFAIK.