### PR TITLE
merge dev tasks into a single command

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "dev": "gro dev",
     "deploy": "NODE_ENV=production node build/project/deploy/deploy.js",
     "deploy:dry": "DEPLOY_DRY_RUN=1 NODE_ENV=production node build/project/deploy/deploy.js",
-    "ts": "tsc -w",
     "start": "node __sapper__/build",
     "test": "echo 'to be decided!'"
   },

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/feltcoop/felt/issues"
   },
   "scripts": {
-    "dev": "sapper dev --src build --routes build/routes --output build/node_modules/@sapper",
     "build": "gro build",
+    "dev": "gro dev",
     "deploy": "NODE_ENV=production node build/project/deploy/deploy.js",
     "deploy:dry": "DEPLOY_DRY_RUN=1 NODE_ENV=production node build/project/deploy/deploy.js",
     "ts": "tsc -w",

--- a/src/build.task.ts
+++ b/src/build.task.ts
@@ -1,17 +1,24 @@
 import {Task} from '@feltcoop/gro';
 import {spawnProcess} from '@feltcoop/gro/dist/utils/process.js';
 
-import {task as devTask} from './dev.task.js';
+import {copyIgnoredBuildFiles} from './project/dev/copyIgnoredBuildFiles.js';
 
+/*
+
+This task builds the app for production.
+It mirrors `./dev.task.ts` in many ways with some important differences -
+mainly, it does nothing in watch mode,
+and in the future there will be more divergence,
+perhaps using completely different tools to improve the dev experience.
+
+*/
 export const task: Task = {
 	description: 'builds everything for production',
-	run: async (ctx): Promise<void> => {
-		const {log} = ctx;
-
+	run: async ({log}): Promise<void> => {
 		log.info('compiling typescript');
 		await spawnProcess('node_modules/.bin/tsc');
 
-		await devTask.run({...ctx, args: {...ctx.args, watch: false}});
+		await copyIgnoredBuildFiles(log, false);
 
 		log.info('building sapper');
 		await spawnProcess('node_modules/.bin/sapper', [

--- a/src/dev.task.ts
+++ b/src/dev.task.ts
@@ -74,14 +74,17 @@ export const task: Task = {
 		await init;
 
 		log.info('starting sapper');
-		await spawnProcess('node_modules/.bin/sapper', [
-			'dev',
-			'--src',
-			'build',
-			'--routes',
-			'build/routes',
-			'--output',
-			'build/node_modules/@sapper',
+		await Promise.all([
+			spawnProcess('node_modules/.bin/sapper', [
+				'dev',
+				'--src',
+				'build',
+				'--routes',
+				'build/routes',
+				'--output',
+				'build/node_modules/@sapper',
+			]),
+			spawnProcess('node_modules/.bin/tsc', ['-w', '--preserveWatchOutput']),
 		]);
 	},
 };

--- a/src/dev.task.ts
+++ b/src/dev.task.ts
@@ -1,79 +1,29 @@
 import {Task} from '@feltcoop/gro';
-import {
-	paths,
-	basePathToSourceId,
-	basePathToBuildId,
-} from '@feltcoop/gro/dist/paths.js';
-import {watchNodeFs, WatcherChange} from '@feltcoop/gro/dist/fs/watchNodeFs.js';
-import {copy, remove} from '@feltcoop/gro/dist/fs/nodeFs.js';
-import {printPath} from '@feltcoop/gro/dist/utils/print.js';
-import {UnreachableError} from '@feltcoop/gro/dist/utils/error.js';
 import {spawnProcess} from '@feltcoop/gro/dist/utils/process.js';
+
+import {copyIgnoredBuildFiles} from './project/dev/copyIgnoredBuildFiles.js';
 
 /*
 
-This task is part of Felt's work-in-progress build process.
-We currently defer compilation of Svelte and TypeScript
-to existing build processes using Rollup and `tsc`.
+Felt's build process currently composes TypeScript's compiler,
+Sapper, and a small utility to glue them together via the `build/` directory.
 
-Eventually, this task will be the sole entrypoint
-for building Felt in development.
-To bridge the target process and the current one,
-this dev task copies certain files to `build/` in watch mode,
-treating `build/` as the old `src/` in the current build tools.
+TypeScript is compiled to `build/`,
+other files like Svelte and HTML are copied to it,
+and then Sapper is pointed to `build/` instead of its normal `src/`.
+
+This writes to disk more than needed and it's more complex than
+doing everything through Rollup, but it gives us more flexibility in the future
+to take advantage of tools that provide big dev-time benefits.
+(e.g. Snowpack, esbuild, etc)
 
 */
-
-const isFileIgnoredByCurrentBuild = (path: string): boolean =>
-	path.endsWith('.svelte') || path.endsWith('.html');
-
 export const task: Task = {
 	description: 'builds the project for development and watches for changes',
 	run: async ({log}): Promise<void> => {
-		const {init} = watchNodeFs({
-			dir: paths.source,
-			onInit: async paths => {
-				log.trace(`init file watcher with ${paths.size} paths`);
-				await Promise.all(
-					Array.from(paths.keys()).map(path => {
-						if (!isFileIgnoredByCurrentBuild(path)) return null;
-						log.trace('copying', printPath(path));
-						return copy(basePathToSourceId(path), basePathToBuildId(path));
-					}),
-				);
-			},
-			onChange: async (change, path, stats) => {
-				switch (change) {
-					case WatcherChange.Create: {
-						if (isFileIgnoredByCurrentBuild(path)) {
-							log.trace('created and copying', printPath(path));
-							await copy(basePathToSourceId(path), basePathToBuildId(path));
-						}
-						break;
-					}
-					case WatcherChange.Update: {
-						if (isFileIgnoredByCurrentBuild(path)) {
-							log.trace('updated and copying', printPath(path));
-							await copy(basePathToSourceId(path), basePathToBuildId(path));
-						}
-						break;
-					}
-					case WatcherChange.Delete: {
-						if (isFileIgnoredByCurrentBuild(path) || stats.isDirectory()) {
-							log.trace('deleted and removing', printPath(path));
-							await remove(basePathToBuildId(path));
-						}
-						break;
-					}
-					default: {
-						throw new UnreachableError(change);
-					}
-				}
-			},
-		});
-		await init;
+		await copyIgnoredBuildFiles(log, true);
 
-		log.info('starting sapper');
+		log.info('starting Sapper and the TypeScript compiler in watch mode');
 		await Promise.all([
 			spawnProcess('node_modules/.bin/sapper', [
 				'dev',

--- a/src/project/dev/copyIgnoredBuildFiles.ts
+++ b/src/project/dev/copyIgnoredBuildFiles.ts
@@ -1,0 +1,71 @@
+import {
+	paths,
+	basePathToSourceId,
+	basePathToBuildId,
+} from '@feltcoop/gro/dist/paths.js';
+import {watchNodeFs, WatcherChange} from '@feltcoop/gro/dist/fs/watchNodeFs.js';
+import {copy, remove} from '@feltcoop/gro/dist/fs/nodeFs.js';
+import {printPath} from '@feltcoop/gro/dist/utils/print.js';
+import {UnreachableError} from '@feltcoop/gro/dist/utils/error.js';
+import {Logger} from '@feltcoop/gro/dist/utils/log';
+
+const isFileIgnoredByCurrentBuild = (path: string): boolean =>
+	path.endsWith('.svelte') || path.endsWith('.html');
+
+/*
+
+We currently defer compilation of Svelte and TypeScript
+to existing build processes using Rollup and `tsc`.
+This helper is used to bridge the gap by moving uncompiled Svelte and HTML
+to the `build/` directory so Sapper can treat it as `src/`.
+
+*/
+export const copyIgnoredBuildFiles = async (
+	log: Logger,
+	watch: boolean,
+): Promise<void> => {
+	const {init, dispose} = watchNodeFs({
+		dir: paths.source,
+		onInit: async paths => {
+			log.trace(`init file watcher with ${paths.size} paths`);
+			await Promise.all(
+				Array.from(paths.keys()).map(path => {
+					if (!isFileIgnoredByCurrentBuild(path)) return null;
+					log.trace('copying', printPath(path));
+					return copy(basePathToSourceId(path), basePathToBuildId(path));
+				}),
+			);
+		},
+		onChange: async (change, path, stats) => {
+			switch (change) {
+				case WatcherChange.Create: {
+					if (isFileIgnoredByCurrentBuild(path)) {
+						log.trace('created and copying', printPath(path));
+						await copy(basePathToSourceId(path), basePathToBuildId(path));
+					}
+					break;
+				}
+				case WatcherChange.Update: {
+					if (isFileIgnoredByCurrentBuild(path)) {
+						log.trace('updated and copying', printPath(path));
+						await copy(basePathToSourceId(path), basePathToBuildId(path));
+					}
+					break;
+				}
+				case WatcherChange.Delete: {
+					if (isFileIgnoredByCurrentBuild(path) || stats.isDirectory()) {
+						log.trace('deleted and removing', printPath(path));
+						await remove(basePathToBuildId(path));
+					}
+					break;
+				}
+				default: {
+					throw new UnreachableError(change);
+				}
+			}
+		},
+	});
+	await init;
+
+	if (!watch) dispose();
+};

--- a/src/project/setup/README.md
+++ b/src/project/setup/README.md
@@ -69,11 +69,8 @@ before [deploying to a production server](../deploy).
 **5. Run the dev server!**
 
 ```bash
-$ npm run ts # compile typescript - let it finish before continuing
-$ gro dev # eventually this will be the only command
+$ gro dev
 ```
-
-> TODO wrap these into a single command
 
 Now open your browser to `localhost:3000` or whatever it says.
 

--- a/src/project/setup/README.md
+++ b/src/project/setup/README.md
@@ -71,7 +71,6 @@ before [deploying to a production server](../deploy).
 ```bash
 $ npm run ts # compile typescript - let it finish before continuing
 $ gro dev # eventually this will be the only command
-$ npm run dev # open a third shell (lol TODO) for the sapper dev server
 ```
 
 > TODO wrap these into a single command


### PR DESCRIPTION
This makes `gro dev` the only command needed for development. It compiles TypeScript in watch mode, runs the Sapper dev server, and copies other changed files into the `build/` directory. There's a lot of room for improvement here to speed up the build, but this gives us enough convenience to move on to more pressing things - like the app!