### PR TITLE
use gro tasks in CI

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -23,8 +23,9 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
-      - run: npm run build
-      - run: npm test
+      - run: npm i -g @feltcoop/gro
+      - run: gro build
+      - run: gro test
         env:
           CI: true
-      - run: node_modules/.bin/gro format --check
+      - run: gro format --check

--- a/package.json
+++ b/package.json
@@ -17,8 +17,6 @@
     "url": "https://github.com/feltcoop/felt/issues"
   },
   "scripts": {
-    "build": "gro build",
-    "dev": "gro dev",
     "start": "node __sapper__/build",
     "test": "gro test"
   },

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "url": "https://github.com/feltcoop/felt/issues"
   },
   "scripts": {
+    "dev": "gro dev",
+    "build": "gro build",
     "start": "node __sapper__/build",
     "test": "gro test"
   },

--- a/src/project/setup/README.md
+++ b/src/project/setup/README.md
@@ -30,7 +30,7 @@ Install it globally to add its CLI to your system PATH:
 
 ```bash
 $ npm i -g @feltcoop/gro
-$ gro # lists all available tasks
+$ gro # lists all available tasks, deferring to the locally installed Gro version
 ```
 
 **4. Initialize .env**

--- a/src/project/setup/README.md
+++ b/src/project/setup/README.md
@@ -30,6 +30,7 @@ Install it globally to add its CLI to your system PATH:
 
 ```bash
 $ npm i -g @feltcoop/gro
+$ gro # lists all available tasks
 ```
 
 **4. Initialize .env**

--- a/src/project/setup/README.md
+++ b/src/project/setup/README.md
@@ -25,6 +25,13 @@ See [`package.json`](/package.json) for more about what's being installed.
 Felt tries to minimize external dependencies within reason -
 if you see avoidable bloat please help us reduce it!
 
+Felt uses [Gro](https://github.com/feltcoop/gro) for task running and other development needs.
+Install it globally to add its CLI to your system PATH:
+
+```bash
+$ npm i -g @feltcoop/gro
+```
+
 **4. Initialize .env**
 
 Copy [`.env.sample`](.env.sample) as `.env` to the root directory.
@@ -69,7 +76,7 @@ before [deploying to a production server](../deploy).
 **5. Run the dev server!**
 
 ```bash
-$ gro dev
+$ gro dev # the globally installed Gro defers to the local version
 ```
 
 Now open your browser to `localhost:3000` or whatever it says.


### PR DESCRIPTION
I looked at the Gradle Wrapper from our discussion in #24 and it made me realize that we have all of the same pieces through npm and Gro's behavior that defers to the local installation of Gro, if one is detected.

This PR installs Gro globally in the CI, which should be cached from the previous command `npm ci` unless Felt is on an older version of Gro. (could be fixed somehow to always use the cached version, but not worth it IMO unless a robust solution appears in front of us without going to search for one)

This matches the preferred workflow for devs on their local machine - it's recommended (though needs documentation (edit: which I added)) to install Gro with `npm i -g @feltcoop/gro` in addition to installing it through a project's `package.json`.

I also removed the "build" and "dev" npm scripts. Do you think we should keep them? (edit: yes we keep) There's an argument to be made for making them more discoverable. I kept "start" and "test", because those are standard expected Node things, but what do you think, should we remove those too?