### PR TITLE
use 'gro check' in CI

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -24,8 +24,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
       - run: npm i -g @feltcoop/gro
-      - run: gro build
-      - run: gro test
+      - run: gro check
         env:
           CI: true
-      - run: gro format --check
+      - run: gro build


### PR DESCRIPTION
Now that `gro check` works on projects that have no gen files, we can call it to perform all of the pre-build checks with one line. Functionally this is the same except it now also typechecks.