### PR TITLE
add a lazy helper for getting enrivonment variables

### DIFF
--- a/src/db/getKnexConnectionConfig.ts
+++ b/src/db/getKnexConnectionConfig.ts
@@ -1,30 +1,31 @@
-import dotenv from 'dotenv';
-dotenv.config();
-const {DB_NAME, DB_USER, DB_PASS, DB_HOST, DB_PORT} = process.env;
-if (!DB_NAME) {
-	throw Error(`Missing envrionment variable "DB_NAME"`);
-}
-if (!DB_USER) {
-	throw Error(`Missing envrionment variable "DB_USER"`);
-}
-if (!DB_PASS) {
-	throw Error(`Missing envrionment variable "DB_PASS"`);
-}
-if (!DB_HOST) {
-	throw Error(`Missing envrionment variable "DB_HOST"`);
-}
-
 import {PgConnectionConfig} from 'knex';
+
+import {getEnv} from '../project/env.js';
 
 type KnexConnectionConfig = PartialExcept<
 	Readonly<Required<PgConnectionConfig>>,
 	'database' | 'user' | 'password' | 'host' | 'port'
 >;
 
-export const getKnexConnectionConfig = (): KnexConnectionConfig => ({
-	database: DB_NAME,
-	user: DB_USER,
-	password: DB_PASS,
-	host: DB_HOST,
-	port: Number(DB_PORT) || 5432,
-});
+export const getKnexConnectionConfig = (): KnexConnectionConfig => {
+	const {DB_NAME, DB_USER, DB_PASS, DB_HOST, DB_PORT} = getEnv();
+	if (!DB_NAME) {
+		throw Error(`Missing envrionment variable "DB_NAME"`);
+	}
+	if (!DB_USER) {
+		throw Error(`Missing envrionment variable "DB_USER"`);
+	}
+	if (!DB_PASS) {
+		throw Error(`Missing envrionment variable "DB_PASS"`);
+	}
+	if (!DB_HOST) {
+		throw Error(`Missing envrionment variable "DB_HOST"`);
+	}
+	return {
+		database: DB_NAME,
+		user: DB_USER,
+		password: DB_PASS,
+		host: DB_HOST,
+		port: Number(DB_PORT) || 5432,
+	};
+};

--- a/src/deploy.task.ts
+++ b/src/deploy.task.ts
@@ -1,5 +1,12 @@
-import dotenv from 'dotenv';
-dotenv.config();
+import * as fileSystem from 'fs';
+import * as filePath from 'path';
+import {exec} from 'child_process';
+import {magenta, cyan, green} from '@feltcoop/gro/dist/colors/terminal.js';
+import {Task} from '@feltcoop/gro';
+
+import {paths} from './paths.js';
+import {getEnv} from './project/env.js';
+
 const {
 	DEPLOY_SERVER_USER,
 	DEPLOY_SERVER_IP,
@@ -7,7 +14,7 @@ const {
 	DEPLOY_SERVER_DIR,
 	DEPLOY_NODE_PROCESS_NAME,
 	SERVER_DEPLOY,
-} = process.env;
+} = getEnv();
 if (!DEPLOY_SERVER_USER && !SERVER_DEPLOY) {
 	throw Error('DEPLOY_SERVER_USER env var is required for deployment');
 }
@@ -20,14 +27,6 @@ if (!DEPLOY_SERVER_DIR) {
 if (!DEPLOY_NODE_PROCESS_NAME) {
 	throw Error('DEPLOY_NODE_PROCESS_NAME env var is required for deployment');
 }
-
-import * as fileSystem from 'fs';
-import * as filePath from 'path';
-import {exec} from 'child_process';
-import {magenta, cyan, green} from '@feltcoop/gro/dist/colors/terminal.js';
-import {Task} from '@feltcoop/gro';
-
-import {paths} from './paths.js';
 
 // ensure the build is ready
 if (!fileSystem.existsSync(paths.sapperBuild)) {

--- a/src/project/env.ts
+++ b/src/project/env.ts
@@ -1,0 +1,11 @@
+import dotenv from 'dotenv';
+
+let isConfigured = false;
+
+export const getEnv = (forceRefresh = false): NodeJS.ProcessEnv => {
+	if (!isConfigured || forceRefresh) {
+		isConfigured = true;
+		dotenv.config();
+	}
+	return process.env;
+};

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,3 @@
-import dotenv from 'dotenv';
 import sirv from 'sirv';
 import polka from 'polka';
 import compression from 'compression';
@@ -8,9 +7,9 @@ import fp from 'path';
 import bodyParser from 'body-parser';
 
 import {isEmail, normalizeEmail} from './client/email/utils.js';
+import {getEnv} from './project/env.js';
 
-dotenv.config();
-const {PORT, NODE_ENV} = process.env;
+const {PORT, NODE_ENV} = getEnv();
 const dev = NODE_ENV === 'development';
 
 // TODO put these in a centralized paths module

--- a/src/setup.task.ts
+++ b/src/setup.task.ts
@@ -1,7 +1,8 @@
-import dotenv from 'dotenv';
 import {Task} from '@feltcoop/gro';
 import {copy, pathExists} from '@feltcoop/gro/dist/fs/nodeFs.js';
 import {spawnProcess} from '@feltcoop/gro/dist/utils/process.js';
+
+import {getEnv} from './project/env.js';
 
 export const task: Task = {
 	description: 'performs initial project setup',
@@ -17,8 +18,7 @@ export const task: Task = {
 		}
 
 		// set up the database - the first two are no-ops if they already exist
-		dotenv.config();
-		const {DB_NAME, DB_USER, DB_PASS} = process.env;
+		const {DB_NAME, DB_USER, DB_PASS} = getEnv(true);
 		if (!DB_NAME) throw Error(`Expected environment variable DB_NAME`);
 		if (!DB_USER) throw Error(`Expected environment variable DB_USER`);
 		if (!DB_PASS) throw Error(`Expected environment variable DB_PASS`);


### PR DESCRIPTION
This adds a standard helper to the project for reading environment variables. Previously we called `dotenv.config()` in multiple places, causing unnecessary work and bugs with the setup task. The helper has a flag to force refreshing the config from the `.env` on disk which is needed by the setup task.

The Knex connection config has to lazily get the config, not eagerly at the module scope, because it errors during the setup task when the `.env` doesn't yet exist. Similarly to the Knex connection config, any code called during setup that relies on environment variables needs to defer loading the config or force a refresh before using them. It should be straightforward to catch those problems, and they shouldn't be too numerous going forward.

In the future we might want to add validation to the module to simplify consumer code.