### PR TITLE
invoke Gro tasks instead of calling them directly

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -43,7 +43,5 @@ jobs:
       - run: npm ci
       - run: npm i -g @feltcoop/gro
       - run: gro setup
-      - run: gro typecheck
-      - run: gro test
-      - run: gro format --check
+      - run: gro check
       - run: gro build

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,9 +25,9 @@
       }
     },
     "@feltcoop/gro": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.1.11.tgz",
-      "integrity": "sha512-YS6aX3S671Rq3N7jCywCNarlugnLmTVLVUDdKjfwSzcVgvEfy0BXAKZszsrkeSO1d/j037hjIKN6doQq0E+Y/Q==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.1.12.tgz",
+      "integrity": "sha512-fqvsFlYlOna4rRp1SNIfmUKrHPOgRpiFyynO6eDF+ovHktCwcrr2EdD0vrDJxa5P/zZppFWHjriWgmcY6M4DLg==",
       "dev": true,
       "requires": {
         "@rollup/plugin-node-resolve": "^7.1.3",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "sirv": "^0.4.0"
   },
   "devDependencies": {
-    "@feltcoop/gro": "^0.1.11",
+    "@feltcoop/gro": "^0.1.12",
     "@rollup/plugin-replace": "^2.3.1",
     "@types/body-parser": "^1.19.0",
     "@types/compression": "^1.7.0",

--- a/src/db/create.task.ts
+++ b/src/db/create.task.ts
@@ -1,18 +1,15 @@
 import {Task} from '@feltcoop/gro/dist/task/task.js';
 
-import {task as destroyTask} from './destroy.task.js';
-import {task as migrateTask} from './migrate.task.js';
-import {task as seedTask} from './seed.task.js';
 import {obtainKnex} from './obtainKnex.js';
 
 export const task: Task = {
 	description: 'create the database from scratch and reset all data',
-	run: async (ctx) => {
+	run: async ({invokeTask}) => {
 		// the sub-tasks all use knex and we don't want it to be torn down each time
 		const [, unobtainKnex] = obtainKnex();
-		await destroyTask.run(ctx);
-		await migrateTask.run(ctx);
-		await seedTask.run(ctx);
+		await invokeTask('db/destroy');
+		await invokeTask('db/migrate');
+		await invokeTask('db/seed');
 		unobtainKnex();
 	},
 };

--- a/src/setup.task.ts
+++ b/src/setup.task.ts
@@ -6,9 +6,7 @@ import {getEnv} from './project/env.js';
 
 export const task: Task = {
 	description: 'performs initial project setup',
-	run: async (ctx): Promise<void> => {
-		const {log} = ctx;
-
+	run: async ({log, invokeTask}): Promise<void> => {
 		// copy a fresh `.env` to the root if one doesn't already exist
 		if (await pathExists('.env')) {
 			log.info('.env already exists - skipping its copy step');
@@ -40,7 +38,6 @@ export const task: Task = {
 		]);
 
 		// create the database's schema and seed it
-		const {task: createDbTask} = await import('./db/create.task.js');
-		await createDbTask.run(ctx);
+		await invokeTask('db/create');
 	},
 };

--- a/src/test.task.ts
+++ b/src/test.task.ts
@@ -1,5 +1,4 @@
 import {Task} from '@feltcoop/gro';
-import {task as testTask} from '@feltcoop/gro/dist/test.task.js';
 import {Unobtain} from '@feltcoop/gro/dist/utils/createObtainable.js';
 
 import {obtainKnex, KnexInstance} from './db/obtainKnex.js';
@@ -15,12 +14,10 @@ export const getKnex = () => {
 
 export const task: Task = {
 	description: 'run tests',
-	run: async (ctx) => {
-		const {log} = ctx;
+	run: async ({invokeTask}) => {
+		await invokeTask('gro/test');
 
-		log.info('testing');
-		await testTask.run(ctx);
-
+		// Tests may open a database connection, so we tear it down here if so.
 		if (unobtainKnex) unobtainKnex();
 	},
 };


### PR DESCRIPTION
The uses the new [Gro `invokeTask` helper](https://github.com/feltcoop/gro/pull/20) to improve Felt's task running. See that PR for more details.

This fixes the `gro check` task by allowing invoked tasks to be overridden by the user. Before, `gro check` imported and called Gro's builtin test task directly, but now that `gro check` uses `invokeTask`, it will correctly defer to tasks the user overrides. Our test task needs to tear down the database connection, so without this change, CI would hang indefinitely when it used `gro check`.

Gro builtin tasks can be explicitly run by [prefixing the task name with `gro/` like we do in `test.task.ts`](https://github.com/feltcoop/felt/compare/invoke-tasks?expand=1#diff-f21cd86761931ec7c42a816949312dc3R18). 

It also significantly improves logging. Tasks invoked by others will now print their start, end, and diagnostics, so it's much clearer what's happening. Doing this with explicit task function calls isn't supported because we don't want to mix logging and diagnostic concerns with the tasks themselves. I was thinking of implementing a `runTask` helper to get around this problem, but `invokeTask` solves both logging and composition.