### PR TITLE
add email authentication flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ node_modules/
 /build
 
 *.ignore.*
+*.ignore
+
+/src/felt.config.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,54 +25,58 @@
       }
     },
     "@feltcoop/gro": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.2.4.tgz",
-      "integrity": "sha512-HYGdsuvyDCCfT9JxHmP5nJK2yN7fDRRQWKJ8LyJUVDV6B7b3Kng0t4N8pB8FADPQdbzITm0c2IMKdKDfnU2Tnw==",
-      "dev": true,
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.2.11.tgz",
+      "integrity": "sha512-gjc0PwwIG9e9tIyxVjDtLB5KSKyeWTFVHCp1uqTNi6/rncLyd43kGeIFmxWEsk7NbFY+PwYS2O3S8szaLhv5Lw==",
       "requires": {
-        "@rollup/plugin-node-resolve": "^7.1.3",
-        "@rollup/pluginutils": "^3.0.10",
-        "@types/fs-extra": "^8.1.0",
-        "@types/node": "^12.12.38",
-        "@types/source-map-support": "^0.5.1",
+        "@lukeed/uuid": "^1.0.1",
+        "@rollup/plugin-node-resolve": "^8.4.0",
+        "@rollup/pluginutils": "^3.1.0",
+        "@types/fs-extra": "^9.0.1",
+        "@types/node": "^12.12.50",
+        "@types/source-map-support": "^0.5.2",
         "cheap-watch": "^1.0.2",
-        "fs-extra": "^9.0.0",
-        "kleur": "^4.0.0",
-        "mri": "^1.1.5",
+        "fs-extra": "^9.0.1",
+        "kleur": "^4.0.2",
+        "mri": "^1.1.6",
         "rollup-plugin-commonjs": "^10.1.0",
         "source-map-support": "^0.5.16",
         "sourcemap-codec": "^1.4.8",
-        "terser": "^4.6.13"
+        "terser": "^4.8.0"
       },
       "dependencies": {
         "@rollup/pluginutils": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
           "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
-          "dev": true,
           "requires": {
             "@types/estree": "0.0.39",
             "estree-walker": "^1.0.1",
             "picomatch": "^2.2.2"
           }
         },
+        "@types/fs-extra": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.1.tgz",
+          "integrity": "sha512-B42Sxuaz09MhC3DDeW5kubRcQ5by4iuVQ0cRRWM2lggLzAa/KVom0Aft/208NgMvNQQZ86s5rVcqDdn/SH0/mg==",
+          "requires": {
+            "@types/node": "*"
+          }
+        },
         "@types/node": {
-          "version": "12.12.48",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.48.tgz",
-          "integrity": "sha512-m3Nmo/YaDUfYzdCQlxjF5pIy7TNyDTAJhIa//xtHcF0dlgYIBKULKnmloCPtByDxtZXrWV8Pge1AKT6/lRvVWg==",
-          "dev": true
+          "version": "12.12.51",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.51.tgz",
+          "integrity": "sha512-6ILqt8iNThALrxDv2Q4LyYFQxULQz96HKNIFd4s9QRQaiHINYeUpLqeU/2IU7YMtvipG1fQVAy//vY8/fX1Y9w=="
         },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "terser": {
           "version": "4.8.0",
           "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
           "integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
-          "dev": true,
           "requires": {
             "commander": "^2.20.0",
             "source-map": "~0.6.1",
@@ -80,6 +84,11 @@
           }
         }
       }
+    },
+    "@lukeed/uuid": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@lukeed/uuid/-/uuid-1.0.1.tgz",
+      "integrity": "sha512-shtopUGL/WuVicOTppRGDb2he9aGp+OF5EB11Xsbe3K4W6qN7HtK3F+ayNxcfbrG/SSL/Z9B+Xrb0Foz9x83gw=="
     },
     "@polka/send-type": {
       "version": "0.5.2",
@@ -92,16 +101,45 @@
       "integrity": "sha512-3NsZsJIA/22P3QUyrEDNA2D133H4j224twJrdipXN38dpnIOzAbUDtOwkcJ5pXmn75w7LSQDjA4tO9dm1XlqlA=="
     },
     "@rollup/plugin-node-resolve": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-7.1.3.tgz",
-      "integrity": "sha512-RxtSL3XmdTAE2byxekYLnx+98kEUOrPHF/KRVjLH+DEIHy6kjIw7YINQzn+NXiH/NTrQLAwYs0GWB+csWygA9Q==",
-      "dev": true,
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-8.4.0.tgz",
+      "integrity": "sha512-LFqKdRLn0ShtQyf6SBYO69bGE1upV6wUhBX0vFOUnLAyzx5cwp8svA0eHUnu8+YU57XOkrMtfG63QOpQx25pHQ==",
       "requires": {
-        "@rollup/pluginutils": "^3.0.8",
-        "@types/resolve": "0.0.8",
+        "@rollup/pluginutils": "^3.1.0",
+        "@types/resolve": "1.17.1",
         "builtin-modules": "^3.1.0",
+        "deep-freeze": "^0.0.1",
+        "deepmerge": "^4.2.2",
         "is-module": "^1.0.0",
-        "resolve": "^1.14.2"
+        "resolve": "^1.17.0"
+      },
+      "dependencies": {
+        "@rollup/pluginutils": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+          "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+          "requires": {
+            "@types/estree": "0.0.39",
+            "estree-walker": "^1.0.1",
+            "picomatch": "^2.2.2"
+          }
+        },
+        "@types/resolve": {
+          "version": "1.17.1",
+          "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
+          "integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "resolve": {
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        }
       }
     },
     "@rollup/plugin-replace": {
@@ -173,8 +211,7 @@
     "@types/estree": {
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
-      "dev": true
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
     },
     "@types/express": {
       "version": "4.17.6",
@@ -223,8 +260,16 @@
     "@types/node": {
       "version": "12.12.32",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.32.tgz",
-      "integrity": "sha512-44/reuCrwiQEsXud3I5X3sqI5jIXAmHB5xoiyKUw965olNHF3IWKjBLKK3F9LOSUZmK+oDt8jmyO637iX+hMgA==",
-      "dev": true
+      "integrity": "sha512-44/reuCrwiQEsXud3I5X3sqI5jIXAmHB5xoiyKUw965olNHF3IWKjBLKK3F9LOSUZmK+oDt8jmyO637iX+hMgA=="
+    },
+    "@types/nodemailer": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.0.tgz",
+      "integrity": "sha512-KY7bFWB0MahRZvVW4CuW83qcCDny59pJJ0MQ5ifvfcjNwPlIT0vW4uARO4u1gtkYnWdhSvURegecY/tzcukJcA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/qs": {
       "version": "6.9.3",
@@ -261,7 +306,6 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/@types/source-map-support/-/source-map-support-0.5.2.tgz",
       "integrity": "sha512-krvWmwQ2Pzr+Yp8tKjhKC9UguRNg1ev9mNdlVVpVJvU9iynulYZsx3ydf1SPzNNxzhmbWAOAIw5hMWhAMDc2NA==",
-      "dev": true,
       "requires": {
         "@types/node": "*",
         "source-map": "^0.6.0"
@@ -270,8 +314,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
     },
@@ -337,8 +380,7 @@
     "at-least-node": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-      "dev": true
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
     },
     "atob": {
       "version": "2.1.2",
@@ -442,8 +484,7 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-      "dev": true
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "buffer-writer": {
       "version": "2.0.0",
@@ -453,8 +494,7 @@
     "builtin-modules": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.1.0.tgz",
-      "integrity": "sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==",
-      "dev": true
+      "integrity": "sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw=="
     },
     "bytes": {
       "version": "3.1.0",
@@ -501,8 +541,7 @@
     "cheap-watch": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/cheap-watch/-/cheap-watch-1.0.2.tgz",
-      "integrity": "sha512-jp82t+kZAW+ZVnuYuHZEGZqDaUg28uAyOhC915BcKBSYL55fpTyuJ56cYYXZG0JkCPQT80MjRD6q2KqebaPwCw==",
-      "dev": true
+      "integrity": "sha512-jp82t+kZAW+ZVnuYuHZEGZqDaUg28uAyOhC915BcKBSYL55fpTyuJ56cYYXZG0JkCPQT80MjRD6q2KqebaPwCw=="
     },
     "class-utils": {
       "version": "0.3.6",
@@ -574,8 +613,7 @@
     "commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "component-emitter": {
       "version": "1.3.0",
@@ -660,6 +698,16 @@
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
+    "deep-freeze": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/deep-freeze/-/deep-freeze-0.0.1.tgz",
+      "integrity": "sha1-OgsABd4YZygZ39OM0x+RF5yJPoQ="
+    },
+    "deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
+    },
     "define-property": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
@@ -731,8 +779,7 @@
     "estree-walker": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
-      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
-      "dev": true
+      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="
     },
     "esutils": {
       "version": "2.0.3",
@@ -937,7 +984,6 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
       "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
-      "dev": true,
       "requires": {
         "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
@@ -987,8 +1033,7 @@
     "graceful-fs": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
-      "dev": true
+      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
     },
     "has-flag": {
       "version": "3.0.0",
@@ -1183,8 +1228,7 @@
     "is-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
-      "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
-      "dev": true
+      "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE="
     },
     "is-number": {
       "version": "3.0.0",
@@ -1216,7 +1260,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.1.4.tgz",
       "integrity": "sha512-uJA/CDPO3Tao3GTrxYn6AwkM4nUPJiGGYu5+cB8qbC7WGFlrKZbiRo7SFKxUAEpFUfiHofWCXBUNhvYJMh+6zw==",
-      "dev": true,
       "requires": {
         "@types/estree": "0.0.39"
       }
@@ -1288,7 +1331,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
       "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
-      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6",
         "universalify": "^1.0.0"
@@ -1310,8 +1352,7 @@
     "kleur": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.0.2.tgz",
-      "integrity": "sha512-FGCCxczbrZuF5CtMeO0xfnjhzkVZSXfcWK90IPLucDWZwskrpYN7pmRIgvd8muU0mrPrzy4A2RBGuwCjLHI+nw==",
-      "dev": true
+      "integrity": "sha512-FGCCxczbrZuF5CtMeO0xfnjhzkVZSXfcWK90IPLucDWZwskrpYN7pmRIgvd8muU0mrPrzy4A2RBGuwCjLHI+nw=="
     },
     "knex": {
       "version": "0.21.1",
@@ -1390,7 +1431,6 @@
       "version": "0.25.6",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.6.tgz",
       "integrity": "sha512-3a5LOMSGoCTH5rbqobC2HuDNRtE2glHZ8J7pK+QZYppyWA36yuNpsX994rIY2nCuyP7CZYy7lQq/X2jygiZ89g==",
-      "dev": true,
       "requires": {
         "sourcemap-codec": "^1.4.4"
       }
@@ -1490,10 +1530,9 @@
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
     },
     "mri": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.5.tgz",
-      "integrity": "sha512-d2RKzMD4JNyHMbnbWnznPaa8vbdlq/4pNZ3IgdaGrVbBhebBsGUUE/6qorTMYNS6TwuH3ilfOlD2bf4Igh8CKg==",
-      "dev": true
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.6.tgz",
+      "integrity": "sha512-oi1b3MfbyGa7FJMP9GmLTttni5JoICpYBRlq+x5V16fZbLsnL9N3wFqqIm/nIG43FjUFkFh9Epzp/kzUGUnJxQ=="
     },
     "ms": {
       "version": "2.0.0",
@@ -1531,6 +1570,11 @@
       "requires": {
         "lower-case": "^1.1.1"
       }
+    },
+    "nodemailer": {
+      "version": "6.4.10",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.4.10.tgz",
+      "integrity": "sha512-j+pS9CURhPgk6r0ENr7dji+As2xZiHSvZeVnzKniLOw1eRAyM/7flP0u65tCnsapV8JFu+t0l/5VeHsCZEeh9g=="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -1731,8 +1775,7 @@
     "picomatch": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
-      "dev": true
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
     },
     "polka": {
       "version": "1.0.0-next.11",
@@ -1883,7 +1926,6 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-10.1.0.tgz",
       "integrity": "sha512-jlXbjZSQg8EIeAAvepNwhJj++qJWNJw1Cl0YnOqKtP5Djx+fFGkp3WRh+W0ASCaFG5w1jhmzDxgu3SJuVxPF4Q==",
-      "dev": true,
       "requires": {
         "estree-walker": "^0.6.1",
         "is-reference": "^1.1.2",
@@ -1895,8 +1937,7 @@
         "estree-walker": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
-          "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
-          "dev": true
+          "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w=="
         }
       }
     },
@@ -1941,7 +1982,6 @@
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
       "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
-      "dev": true,
       "requires": {
         "estree-walker": "^0.6.1"
       },
@@ -1949,8 +1989,7 @@
         "estree-walker": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
-          "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
-          "dev": true
+          "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w=="
         }
       }
     },
@@ -2157,7 +2196,6 @@
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
       "integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
-      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -2166,8 +2204,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
     },
@@ -2179,8 +2216,7 @@
     "sourcemap-codec": {
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-      "dev": true
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
     },
     "split": {
       "version": "1.0.1",
@@ -2391,8 +2427,7 @@
     "universalify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-      "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
-      "dev": true
+      "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug=="
     },
     "unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -23,18 +23,19 @@
     "test": "gro test"
   },
   "dependencies": {
+    "@feltcoop/gro": "^0.2.11",
     "@polka/send-type": "^0.5.2",
     "body-parser": "^1.19.0",
     "compression": "^1.7.1",
     "cookie-session": "^1.4.0",
     "dotenv": "^8.2.0",
     "knex": "^0.21.1",
+    "nodemailer": "^6.4.10",
     "pg": "^8.2.1",
     "polka": "next",
     "sirv": "^0.4.0"
   },
   "devDependencies": {
-    "@feltcoop/gro": "^0.2.4",
     "@rollup/plugin-replace": "^2.3.1",
     "@types/body-parser": "^1.19.0",
     "@types/compression": "^1.7.0",
@@ -42,6 +43,7 @@
     "@types/dotenv": "^8.2.0",
     "@types/fs-extra": "^8.1.0",
     "@types/node": "^12.12.32",
+    "@types/nodemailer": "^6.4.0",
     "@types/trouter": "^3.1.0",
     "prettier": "^2.0.5",
     "prettier-plugin-svelte": "^1.1.0",

--- a/src/accounts/AccountsRepo.test.ts
+++ b/src/accounts/AccountsRepo.test.ts
@@ -15,7 +15,7 @@ test('AccountsRepo', () => {
 		test('creates an account with a case-insensitive email address', async () => {
 			const result = await accountsRepo.create({email: testEmailUppercase});
 			t.ok(result.ok);
-			t.equal(result.value.email, testEmail);
+			t.is(result.value.email, testEmail);
 			testAccount = result.value;
 		});
 		test('fails to create an account with a duplicate email', async () => {

--- a/src/accounts/LoginModel.ts
+++ b/src/accounts/LoginModel.ts
@@ -1,0 +1,13 @@
+import {ModelId} from '../db/Model.js';
+import {AccountModelId} from './AccountModel.js';
+
+export type LoginModelId = ModelId<LoginModel>;
+
+export interface LoginModel {
+	id: LoginModelId;
+	createdAt: Date;
+	expiresAt: Date;
+	account: AccountModelId;
+	secret: string;
+	redirectPath: string | null;
+}

--- a/src/accounts/LoginsRepo.test.ts
+++ b/src/accounts/LoginsRepo.test.ts
@@ -1,0 +1,85 @@
+import {test, t} from '@feltcoop/gro';
+
+import {LoginsRepo} from './LoginsRepo.js';
+import {getKnex} from '../test.task.js';
+import {LoginModel} from './LoginModel.js';
+
+test('LoginsRepo', () => {
+	const loginsRepo = new LoginsRepo(getKnex());
+	const testAccountId = 1;
+	const testRedirectPath = '/redirect';
+	let testLogin: LoginModel;
+	let testLoginUnhashedSecret: string;
+
+	test('create()', async () => {
+		test('creates a login with a redirect path', async () => {
+			const result = await loginsRepo.create(testAccountId, testRedirectPath);
+			t.ok(result.ok);
+			t.ok(result.value.id);
+			t.ok(result.value.createdAt);
+			t.ok(result.value.expiresAt);
+			t.ok(result.value.expiresAt.valueOf() - result.value.createdAt.valueOf() > 1000 * 60);
+			t.ok(result.value.secret);
+			t.is(result.value.account, testAccountId);
+			t.is(result.value.redirectPath, testRedirectPath);
+			testLogin = result.value;
+			testLoginUnhashedSecret = result.unhashedSecret;
+		});
+		test('creates a login without a redirect path', async () => {
+			const result = await loginsRepo.create(testAccountId);
+			t.ok(result.ok);
+			t.is(result.value.redirectPath, null);
+		});
+		test('errors with an invalid account id', async () => {
+			await t.rejects(loginsRepo.create(-1));
+		});
+		test('errors with an undefined account id', async () => {
+			// bypass the type system as a security check
+			await t.rejects(loginsRepo.create(undefined as any));
+			await t.rejects(loginsRepo.create(null as any));
+		});
+	});
+
+	test('findBySecret()', async () => {
+		test('finds one by secret', async () => {
+			const result = await loginsRepo.findBySecret(testLoginUnhashedSecret);
+			t.ok(result.ok);
+			t.equal(result.value, testLogin);
+		});
+		test('fails to find with a hashed secret', async () => {
+			const result = await loginsRepo.findBySecret(testLogin.secret);
+			t.ok(!result.ok);
+			t.is(result.type, 'noLoginFound');
+		});
+		test('fails to find a nonexistent login', async () => {
+			const result = await loginsRepo.findBySecret('fakesecret');
+			t.ok(!result.ok);
+			t.is(result.type, 'noLoginFound');
+		});
+		test('errors with an undefined id', async () => {
+			// bypass the type system as a security check
+			await t.rejects(loginsRepo.findBySecret(undefined as any));
+		});
+	});
+
+	test('deleteById()', async () => {
+		test('deletes one by id', async () => {
+			const findResultBefore = await loginsRepo.findBySecret(testLoginUnhashedSecret);
+			t.ok(findResultBefore.ok);
+			const result = await loginsRepo.deleteById(findResultBefore.value.id);
+			t.ok(result.ok);
+			const findResultAfter = await loginsRepo.findBySecret(testLoginUnhashedSecret);
+			t.ok(!findResultAfter.ok);
+			t.is(findResultAfter.type, 'noLoginFound');
+		});
+		test('fails with an invalid id', async () => {
+			const result = await loginsRepo.deleteById(-1);
+			t.ok(!result.ok);
+			t.is(result.type, 'noLoginFound');
+		});
+		test('errors with an undefined id', async () => {
+			// bypass the type system as a security check
+			await t.rejects(loginsRepo.deleteById(undefined as any));
+		});
+	});
+});

--- a/src/accounts/LoginsRepo.ts
+++ b/src/accounts/LoginsRepo.ts
@@ -1,0 +1,57 @@
+import {createHash, randomBytes} from 'crypto';
+
+import {Repo} from '../db/Repo.js';
+import {LoginModel, LoginModelId} from './LoginModel.js';
+import {AccountModelId} from './AccountModel.js';
+
+export class LoginsRepo extends Repo<LoginModel> {
+	name = 'logins';
+
+	expirationDuration = 1000 * 60 * 10; // 10 minutes
+
+	async create(
+		accountId: AccountModelId,
+		redirectPath: string | null = null,
+	): Promise<Result<{value: LoginModel; unhashedSecret: string}>> {
+		const unhashedSecret = createUnhashedSecret();
+		const secret = hashSecret(unhashedSecret);
+		const value = (
+			await this.query()
+				.insert({
+					account: accountId,
+					secret,
+					redirectPath,
+					expiresAt: new Date(Date.now() + this.expirationDuration),
+				})
+				.returning('*')
+		)[0];
+		return {ok: true, value, unhashedSecret};
+	}
+
+	async findBySecret(
+		unhashedSecret: string,
+	): Promise<Result<{value: LoginModel}, {type: 'noLoginFound'; reason: string}>> {
+		const secret = hashSecret(unhashedSecret);
+		const value = await this.query().where('secret', secret).first();
+		return value
+			? {ok: true, value}
+			: {ok: false, type: 'noLoginFound', reason: `Cannot find login for '${unhashedSecret}'.`};
+	}
+
+	async deleteById(id: LoginModelId): Promise<Result<{}, {type: 'noLoginFound'; reason: string}>> {
+		const count = await this.query().where('id', id).delete();
+		return count === 1
+			? {ok: true}
+			: {ok: false, type: 'noLoginFound', reason: `Failed to delete login with id '${id}'.`};
+	}
+}
+
+// TODO move to shared utilities?
+// The unhashed secret uses hex string encoding to avoid URL-encoding special characters,
+// and the stored hash value uses base64 encoding for efficiency.
+// Using utf8 can fail because Postgres does not allow the NULL character in text fields.
+// There may be a more optimal datatype.
+const UNHASHED_SECRET_BYTE_SIZE = 16; // 128 bit, plenty secure with sha256 and 10 minute expiry!
+const createUnhashedSecret = (): string => randomBytes(UNHASHED_SECRET_BYTE_SIZE).toString('hex');
+const hashSecret = (unhashedSecret: string): string =>
+	createHash('sha256').update(Buffer.from(unhashedSecret, 'hex')).digest().toString('base64');

--- a/src/accounts/loginWithSecretMiddleware.ts
+++ b/src/accounts/loginWithSecretMiddleware.ts
@@ -1,0 +1,72 @@
+import {Middleware} from 'polka';
+import send from '@polka/send-type';
+import {noop} from '@feltcoop/gro/dist/utils/function.js';
+
+import {Server} from '../server/Server.js';
+
+export const loginWithSecretMiddleware = (server: Server): Middleware => {
+	const serverOrigin = server.config.server.origin;
+
+	return async (req, res) => {
+		// TODO schema validation for params
+		const {secret} = req.params;
+
+		// Load the login matching the secret code.
+		const findLoginResult = await server.db.repos.logins.findBySecret(secret);
+		// TODO better error handling - maybe redirect to an error page with a login form?
+		// or at minimum render an HTML page that linkifies the website
+		if (!findLoginResult.ok) {
+			if (findLoginResult.type === 'noLoginFound') {
+				// TODO Because we're deleting the logins, we can't check whether or not
+				// the user is already logged into the requested account,
+				// and just redirect to the normal website instead of displaying an error.
+				// One possible solution that doesn't require storing the login record
+				// would be encoding the account in the login link.
+				// A downside is that would leak account IDs in every email -
+				// it's a small thing but probably worth considering carefully.
+				return send(
+					res,
+					404,
+					`Invalid login attempt. This link was probably already used or expired.` +
+						` Please try again at ${serverOrigin}`,
+				);
+			} else {
+				return send(res, 400, `Unknown server error: ${findLoginResult.reason}`);
+			}
+		}
+		const login = findLoginResult.value;
+
+		// Delete the login so it can be used only once.
+		// We don't need to await the promise or handle errors
+		// because expired logins will be cleaned up automatically.
+		server.db.repos.logins.deleteById(login.id).catch(noop);
+
+		// Check if the login has expired.
+		if (login.expiresAt < new Date()) {
+			return send(res, 400, `This login link has expired. Please try again at ${serverOrigin}`);
+		}
+
+		// Load the account associated with the login.
+		const findAccountResult = await server.db.repos.accounts.findById(login.account);
+		if (!findAccountResult.ok) {
+			// Failed for some unknown reason.
+			return send(res, 400, findAccountResult.reason);
+		}
+		const account = findAccountResult.value;
+
+		// Assign the account to the request, just in case future code expects it.
+		req.account = account;
+
+		// Assign the trusted identity to the session cookie.
+		req.session.email = account.email;
+		console.log('logging into account', account); // TODO logging
+
+		// Redirect to the specified path or the root if there is none.
+		// Include the server origin so it's always scoped to this domain,
+		// so malicious logins can't send people to other websites.
+		// We could use the `referer` header instead,
+		// but it doesn't include the hash path which we'll likely use in the future.
+		res.writeHead(303, {Location: `${serverOrigin}${login.redirectPath || ''}`});
+		res.end();
+	};
+};

--- a/src/client/ui/AccountLoginForm.svelte
+++ b/src/client/ui/AccountLoginForm.svelte
@@ -48,7 +48,10 @@
 			const response = await fetch('/api/v1/accounts/login', {
 				method: 'POST',
 				headers: {'Content-Type': 'application/json'},
-				body: JSON.stringify({email}),
+				body: JSON.stringify({
+					email,
+					redirectPath: window.location.href.slice(window.location.origin.length),
+				}),
 			});
 			const responseData = await response.json();
 			console.log('responseData', responseData); // TODO logging
@@ -56,7 +59,11 @@
 				submittedEmail = email;
 				email = '';
 				errorMessage = '';
-				$session = responseData.session;
+				if (responseData.session) {
+					// In dev mode, email login is bypassed by default,
+					// so if it returns a session, we can use it directly.
+					$session = responseData.session;
+				}
 			} else {
 				console.error('response', response); // TODO logging
 				errorMessage = `Something went wrong. Maybe check your Internet connection? Here's what the server said: "${responseData.reason}"`;

--- a/src/db/Db.ts
+++ b/src/db/Db.ts
@@ -2,6 +2,7 @@ import {Unobtain} from '@feltcoop/gro/dist/utils/createObtainable';
 
 import {obtainKnex, KnexInstance} from './obtainKnex.js';
 import {AccountsRepo} from '../accounts/AccountsRepo.js';
+import {LoginsRepo} from '../accounts/LoginsRepo.js';
 
 /*
 
@@ -25,6 +26,7 @@ export class Db {
 		this.unobtainKnex = unobtainKnex;
 		this.repos = {
 			accounts: new AccountsRepo(knex),
+			logins: new LoginsRepo(knex),
 		};
 	}
 
@@ -35,4 +37,5 @@ export class Db {
 
 interface DbRepos {
 	readonly accounts: AccountsRepo;
+	readonly logins: LoginsRepo;
 }

--- a/src/db/migrations/20200403163837_init.ts
+++ b/src/db/migrations/20200403163837_init.ts
@@ -5,4 +5,14 @@ export const up = async (knex: KnexInstance) => {
 		t.increments();
 		t.text('email').unique();
 	});
+
+	await knex.schema.createTable('logins', (t) => {
+		t.increments();
+		t.dateTime('createdAt').defaultTo(knex.fn.now());
+		t.dateTime('expiresAt').notNullable();
+		t.integer('account').unsigned().notNullable();
+		t.foreign('account').references('id').inTable('accounts');
+		t.text('secret').index().notNullable();
+		t.text('redirectPath');
+	});
 };

--- a/src/project/config.ts
+++ b/src/project/config.ts
@@ -1,0 +1,116 @@
+import SMTPTransport from 'nodemailer/lib/smtp-transport.js';
+import {SendMailOptions} from 'nodemailer';
+import {join} from 'path';
+import {toSourceId} from '@feltcoop/gro/dist/paths.js';
+import {existsSync} from 'fs';
+
+import {getEnv} from './env.js';
+import {paths} from '../paths.js';
+
+/*
+
+The Felt config lets dependent projects define a config file
+at  `felt.config.ts` file in either `src/` or `src/project`.
+
+When developing Felt, this resolves to `./felt.config.ts`,
+which is `${FELT_DIR}/src/project/felt.config.ts`.
+
+*/
+
+const {NODE_ENV} = getEnv();
+const __DEV__ = NODE_ENV === 'development'; // TODO replace in build step
+
+// See `./felt.config.ts` for documentation.
+export interface FeltConfig {
+	server: {
+		port: string;
+		origin: string;
+	};
+	email: {
+		isEnabled: boolean;
+		smtpTransportOptions: SMTPTransport.Options;
+		getLoginEmail: (accountEmail: string, loginUrl: string) => SendMailOptions;
+	};
+}
+
+export interface CreateFeltConfigModule {
+	createConfig: CreateFeltConfig;
+}
+export interface CreateFeltConfig {
+	(options: CreateFeltConfigOptions): Promise<FeltConfig>;
+}
+export interface CreateFeltConfigOptions {
+	env: NodeJS.ProcessEnv;
+}
+
+const CONFIG_FILE_NAME = 'felt.config.js';
+
+let config: FeltConfig | undefined;
+
+export const loadConfig = async (forceRefresh = false): Promise<FeltConfig> => {
+	if (config && !forceRefresh) return config;
+
+	const env = getEnv();
+
+	// Check if there's a config located at `${cwd}/src/felt.config.ts`.
+	// If it doesn't exist, fall back to Felt's default config
+	// located at `felt/src/project/felt.config.ts`.
+
+	// TODO these are broken outside of dev mode right now -
+	// we need to fix the server build to include the config file,
+	// and we need to do several things, including making the local version work,
+	// so Felt can be used as a dependency in other projects
+	const localConfigFilePath = join(paths.build, CONFIG_FILE_NAME);
+	const defaultConfigFilePath = join(paths.build, 'project', CONFIG_FILE_NAME);
+	let configFilePath: string;
+	if (existsSync(toSourceId(localConfigFilePath))) {
+		if (!existsSync(localConfigFilePath)) {
+			throw Error(
+				`Found a local Felt config source file but not the built version. ` +
+					`Do you need to run 'gro dev'?`,
+			);
+		}
+		configFilePath = localConfigFilePath;
+	} else {
+		configFilePath = defaultConfigFilePath;
+	}
+
+	const createConfigModule = await importConfig(configFilePath);
+	const {createConfig} = createConfigModule;
+
+	config = await createConfig({env});
+
+	const result = validateConfig(config);
+	if (!result.ok) {
+		throw Error(`Invalid Felt config: ${result.reason}`);
+	}
+
+	return config;
+};
+
+const importConfig = async (configPath: string): Promise<CreateFeltConfigModule> => {
+	const mod = await import(configPath);
+	if (typeof mod.createConfig !== 'function') {
+		throw Error(
+			`Invalid Felt config module. ` +
+				`Expected a 'createConfig' function export from ${configPath}.`,
+		);
+	}
+	return mod;
+};
+
+export const validateConfig = (config: FeltConfig): Result<{}, {reason: string}> => {
+	// Validate the `email` object.
+	if (!__DEV__ && !config.email.isEnabled) {
+		return {ok: false, reason: `Email must be enabled for production.`};
+	}
+	if (config.email.isEnabled && !config.email.smtpTransportOptions) {
+		return {
+			ok: false,
+			reason:
+				`Email is enabled but there is no nodemailer configuration. ` +
+				`Please either disable email or add a nodemail config object.`,
+		};
+	}
+	return {ok: true};
+};

--- a/src/project/felt.config.ts
+++ b/src/project/felt.config.ts
@@ -1,0 +1,77 @@
+import {FeltConfig, CreateFeltConfig} from './config.js';
+
+/*
+
+This file provides a default Felt config.
+It should work for developing both Felt and Felt-dependent projects
+without any deployment-specific information.
+To extend it, make a copy at `src/felt.config.ts` and edit the values as necessary.
+
+*/
+
+const appName = 'EXAMPLE APP';
+const domain = 'EXAMPLE.com';
+const helpEmailAddress = 'help@EXAMPLE.com';
+
+// For convenience in development,
+// you can safely toggle this flag to enable or disable email authentication.
+// The flag is ignored in production.
+const enableEmailInDevelopment = false;
+
+export const createConfig: CreateFeltConfig = async ({env}) => {
+	const {NODE_ENV, PORT} = env;
+	const __DEV__ = NODE_ENV === 'development';
+	const port = PORT || '3000';
+
+	const config: FeltConfig = {
+		server: {
+			port,
+			origin: __DEV__ ? `http://localhost:${port}` : `https://${domain}`,
+		},
+		email: {
+			isEnabled: __DEV__ ? enableEmailInDevelopment : true,
+			smtpTransportOptions: {
+				// This is the argument passed to `nodemailer.createTransport`. It can take many forms.
+				// See the nodemailer SMTP transport options docs at https://nodemailer.com/smtp/
+				host: 'smtp.EXAMPLE-PROVIDER.com',
+				port: 465,
+				secure: true,
+				auth: {
+					user: 'EXAMPLE_USERNAME',
+					pass: 'EXAMPLE_PASSWORD',
+				},
+			},
+			getLoginEmail: (accountEmail, loginUrl) => {
+				return {
+					from: 'from@EXAMPLE.com',
+					to: accountEmail,
+					subject: `${appName} login`,
+					html: getHtmlLoginEmail(loginUrl),
+					text: getPlainTextLoginEmail(loginUrl),
+				};
+			},
+		},
+	};
+
+	return config;
+};
+
+const getHtmlLoginEmail = (loginUrl: string): string => {
+	return `<a href="${loginUrl}">Click here to log into ${appName}.</a>
+	
+<p>${getFooterText()}</p>
+<p><a href="${loginUrl}">💚</a></p>`;
+};
+
+const getPlainTextLoginEmail = (loginUrl: string): string => {
+	return `Here's your link to into ${appName}: ${loginUrl}
+
+${getFooterText()}
+
+💚`;
+};
+
+const getFooterText = (): string => `
+If you did not request this email, you can safely ignore it.
+To report abuse, please contact ${helpEmailAddress}.
+`;

--- a/src/project/setup/README.md
+++ b/src/project/setup/README.md
@@ -74,7 +74,23 @@ $ sudo -u postgres createdb felt_dev # same as DB_NAME
 Note that you'll have to add additional config to this file
 before [deploying to a production server](../deploy).
 
-**6. Run the dev server!**
+**6. Set up email authentication**
+
+Felt uses email for account creation and login.
+In production, email is always enabled,
+and in development mode, it's optional and bypassed by default.
+
+To configure email for development or production,
+see the `email` field of [`felt.config.ts`](../felt.config.ts).
+The `email.smtpTransportOptions` field is a
+[nodemailer](https://github.com/nodemailer/nodemailer)
+config object that's
+[passed to `nodemailer.createTransport`](https://nodemailer.com/smtp/).
+
+> TODO fully document the config file and link it from here
+> (the config file already has some documentation, but it needs more)
+
+**7. Run the dev server!**
 
 ```bash
 $ gro dev # the globally installed Gro defers to the local version

--- a/src/routes/_error.svelte
+++ b/src/routes/_error.svelte
@@ -2,7 +2,7 @@
 	export let status;
 	export let error;
 
-	const dev = process.env.NODE_ENV === 'development';
+	const __DEV__ = process.env.NODE_ENV === 'development'; // TODO replace in build step
 </script>
 
 <svelte:head>
@@ -13,6 +13,6 @@
 
 <p>{error.message}</p>
 
-{#if dev && error.stack}
+{#if __DEV__ && error.stack}
 	<pre>{error.stack}</pre>
 {/if}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,3 +1,12 @@
 import {Server} from './server/Server.js';
+import {loadConfig} from './project/config.js';
 
-export const server = new Server();
+// Once top-level await arrives in Node without a CLI flag,
+// we can remove this boilerplate and directly export the `server` instance.
+const createServer = async () => {
+	const config = await loadConfig();
+	const server = new Server(config).init();
+	return server;
+};
+
+createServer();


### PR DESCRIPTION
This adds the email authentication flow. This PR adds one database table, `logins`, which is used in a pair of middleware, [one at the login route](https://github.com/feltcoop/felt/pull/35/files#diff-e736da7dbed8b65b65c9a1fd2633eb6e), and [one at the route that the emailed login links point to](https://github.com/feltcoop/felt/pull/35/files#diff-16fd2ba54c09c5d7e5f5bb768cfc7611).

It also adds `src/project/felt.config.ts`. The idea is to make an extensible config that allows other projects to easily customize and deploy their own whitelabelled versions of Felt. Custom configs can be used in both this repo and other projects by defining `src/felt.config.ts`. This is documented in [the setup doc](https://github.com/feltcoop/felt/pull/35/files#diff-3af9cba5a40dc334abf684fdcb2f3fce), [the config module](https://github.com/feltcoop/felt/pull/35/files#diff-a901b484e3ee6d3277dc449a47a3b1f1), and [the default configuration file `src/project/felt.config.ts`](https://github.com/feltcoop/felt/pull/35/files#diff-72cbbd6359ba568c44b3c07efed6ab0e).

There are some rough edges in the config implementation. Felt needs more work to be usable by an external project - we'll get around to that when we start implementing felt.social.

For now, the config file is expected to return a complete config object, not just a partial - I'm open to discussing that. For now I think it's good to have everything in view so nothing is hidden. It's going to grow in complexity so we'll probably want helpers or merge behavior or a bigger API change.

The motivating usecase for the config is email. We currently expose some of [nodemailer](https://github.com/nodemailer/nodemailer)'s API so we can remain agnostic to the transport and authentication. More flexibility might be needed, including going beyond nodemailer, but this is good for now. This seems to be pointing to something like a plugin system.
