### PR TITLE
run db migrations when starting dev task

### DIFF
--- a/src/dev.task.ts
+++ b/src/dev.task.ts
@@ -20,9 +20,10 @@ to take advantage of tools that provide big dev-time benefits.
 */
 export const task: Task = {
 	description: 'builds the project for development and watches for changes',
-	run: async ({log}): Promise<void> => {
+	run: async ({log, invokeTask}): Promise<void> => {
 		await spawnProcess('node_modules/.bin/tsc', ['--preserveWatchOutput']);
-		await copyIgnoredBuildFiles(log, true);
+
+		await Promise.all([copyIgnoredBuildFiles(log, true), invokeTask('db/migrate')]);
 
 		log.info('starting Sapper and the TypeScript compiler in watch mode');
 		await Promise.all([


### PR DESCRIPTION
This should resolve [the issue mentioned here](https://github.com/feltcoop/gro/issues/32) - the `gro dev` task now ensures database migrations are current when it starts up. It doesn't seed automatically, instead that only happens on `gro db/create` or `gro db/seed`. Might be desirable to somehow do that too but I'm not sure of a good way to detect if there's any missing seed data.