### PR TITLE
add reset task

### DIFF
--- a/src/build.task.ts
+++ b/src/build.task.ts
@@ -15,9 +15,8 @@ perhaps using completely different tools to improve the dev experience.
 export const task: Task = {
 	description: 'builds everything for production',
 	run: async ({log}): Promise<void> => {
-		log.info('compiling typescript');
+		log.info('compiling TypeScript');
 		await spawnProcess('node_modules/.bin/tsc');
-
 		await copyIgnoredBuildFiles(log, false);
 
 		log.info('building sapper');

--- a/src/dev.task.ts
+++ b/src/dev.task.ts
@@ -21,7 +21,8 @@ to take advantage of tools that provide big dev-time benefits.
 export const task: Task = {
 	description: 'builds the project for development and watches for changes',
 	run: async ({log}): Promise<void> => {
-		await spawnProcess('node_modules/.bin/tsc', ['--preserveWatchOutput']);
+		log.info('compiling TypeScript');
+		await spawnProcess('node_modules/.bin/tsc');
 		await copyIgnoredBuildFiles(log, true);
 
 		log.info('starting Sapper and the TypeScript compiler in watch mode');

--- a/src/reset.task.ts
+++ b/src/reset.task.ts
@@ -1,0 +1,21 @@
+import {Task} from '@feltcoop/gro';
+import {spawnProcess} from '@feltcoop/gro/dist/utils/process.js';
+
+import {copyIgnoredBuildFiles} from './project/dev/copyIgnoredBuildFiles.js';
+
+export const task: Task = {
+	description: 'resets the local development environment to its initial ready state',
+	run: async ({log, invokeTask}): Promise<void> => {
+		// ensure all dependencies are installed
+		await spawnProcess('npm', ['install']);
+
+		// rebuild everything
+		await invokeTask('clean');
+		log.info('compiling TypeScript');
+		await spawnProcess('node_modules/.bin/tsc');
+		await copyIgnoredBuildFiles(log, false);
+
+		// set up the database, clearing all data and running all migrations
+		await invokeTask('db/create');
+	},
+};


### PR DESCRIPTION
This adds the `gro reset` task for resetting the local development environment to its fresh initial state.

It's useful to run this after switching to a new branch or pulling updates that change dependencies or migrations. Here's [the rejected PR that prompted this addition](https://github.com/feltcoop/felt/pull/36).

Note that it destroys the database so all data will be lost. We may want to put this behind a CLI prompt to confirm.