### PR TITLE
add personas

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -37,9 +37,9 @@ export default {
 			commonjs(),
 
 			!dev &&
-				terser({
-					module: true,
-				}),
+			terser({
+				module: true,
+			}),
 		],
 
 		onwarn,

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -37,9 +37,9 @@ export default {
 			commonjs(),
 
 			!dev &&
-			terser({
-				module: true,
-			}),
+				terser({
+					module: true,
+				}),
 		],
 
 		onwarn,

--- a/src/accounts/AccountsRepo.test.ts
+++ b/src/accounts/AccountsRepo.test.ts
@@ -46,7 +46,13 @@ test('AccountsRepo', () => {
 			t.equal(result.value, testAccount);
 		});
 		test('fails to find a nonexistent account', async () => {
-			const result = await accountsRepo.findById(0);
+			const result = await accountsRepo.findById(-1);
+			t.ok(!result.ok);
+			t.is(result.type, 'noAccountFound');
+		});
+		test('fails to find a null account', async () => {
+			// bypass the type system as a security check - accounts are extra important!
+			const result = await accountsRepo.findById(null as any);
 			t.ok(!result.ok);
 			t.is(result.type, 'noAccountFound');
 		});
@@ -68,7 +74,7 @@ test('AccountsRepo', () => {
 			t.equal(result.value, testAccount);
 		});
 		test('fails to find a nonexistent account', async () => {
-			const result = await accountsRepo.findByEmail(`dont_add_to_db@email.com`);
+			const result = await accountsRepo.findByEmail(`not_in_db@email.com`);
 			t.ok(!result.ok);
 			t.is(result.type, 'noAccountFound');
 		});
@@ -76,6 +82,10 @@ test('AccountsRepo', () => {
 			const result = await accountsRepo.findByEmail('not_an_email');
 			t.ok(!result.ok);
 			t.is(result.type, 'invalidEmail');
+		});
+		test('errors with a null email', async () => {
+			// bypass the type system as a security check - accounts are extra important!
+			await t.rejects(accountsRepo.findByEmail(null as any));
 		});
 		test('errors with an undefined email', async () => {
 			// bypass the type system as a security check - accounts are extra important!

--- a/src/accounts/LoginsRepo.test.ts
+++ b/src/accounts/LoginsRepo.test.ts
@@ -33,10 +33,13 @@ test('LoginsRepo', () => {
 		test('errors with an invalid account id', async () => {
 			await t.rejects(loginsRepo.create(-1));
 		});
+		test('errors with a null account id', async () => {
+			// bypass the type system as a security check
+			await t.rejects(loginsRepo.create(null as any));
+		});
 		test('errors with an undefined account id', async () => {
 			// bypass the type system as a security check
 			await t.rejects(loginsRepo.create(undefined as any));
-			await t.rejects(loginsRepo.create(null as any));
 		});
 	});
 
@@ -56,6 +59,10 @@ test('LoginsRepo', () => {
 			t.ok(!result.ok);
 			t.is(result.type, 'noLoginFound');
 		});
+		test('errors with a null id', async () => {
+			// bypass the type system as a security check
+			await t.rejects(loginsRepo.findBySecret(null as any));
+		});
 		test('errors with an undefined id', async () => {
 			// bypass the type system as a security check
 			await t.rejects(loginsRepo.findBySecret(undefined as any));
@@ -74,6 +81,12 @@ test('LoginsRepo', () => {
 		});
 		test('fails with an invalid id', async () => {
 			const result = await loginsRepo.deleteById(-1);
+			t.ok(!result.ok);
+			t.is(result.type, 'noLoginFound');
+		});
+		test('fails with a null id', async () => {
+			// bypass the type system as a security check
+			const result = await loginsRepo.deleteById(null as any);
 			t.ok(!result.ok);
 			t.is(result.type, 'noLoginFound');
 		});

--- a/src/accounts/accountLoginMiddleware.ts
+++ b/src/accounts/accountLoginMiddleware.ts
@@ -4,7 +4,7 @@ import send from '@polka/send-type';
 import {isEmail, normalizeEmail} from '../client/email/email.js';
 import {Server} from '../server/Server.js';
 import {AccountModel} from './AccountModel.js';
-import {ClientSession} from '../client/session/session.js';
+import {loadClientSession} from '../db/loadClientSession.js';
 
 export const accountLoginMiddleware = (server: Server): Middleware => {
 	return async (req, res) => {
@@ -60,7 +60,7 @@ export const accountLoginMiddleware = (server: Server): Middleware => {
 			// In development, that's every submission with no security.
 			req.session.email = account.email;
 			console.log('bypassing email login', account); // TODO logging
-			const clientSession: ClientSession = {account};
+			const clientSession = await loadClientSession(server.db, account);
 			return send(res, 200, {session: clientSession}); // TODO API types
 		} else {
 			// Send an email with the login link.

--- a/src/client/persona/CreatePersona.svelte
+++ b/src/client/persona/CreatePersona.svelte
@@ -1,0 +1,71 @@
+<script>
+	export let session;
+
+	let newPersonaName = 'persona_' + ((Math.random() * 1000000) | 0);
+
+	let errorMessage = null;
+	let isSubmitting = false;
+	let buttonEl;
+	let inputEl;
+
+	const isName = (str) => str.length > 0; // TODO see discussion in src/personas/PersonasRepo.ts
+
+	const createPersona = async (name) => {
+		if (!name) {
+			inputEl.focus();
+			errorMessage = 'please enter a persona name';
+			return;
+		}
+		if (!isName(name)) {
+			inputEl.focus();
+			errorMessage = 'please enter a valid persona name';
+			return;
+		}
+		buttonEl.focus();
+		isSubmitting = true;
+		errorMessage = '';
+		try {
+			// TODO '/api/v1/personas/create' ?
+			const response = await fetch('/api/v1/personas', {
+				method: 'POST',
+				headers: {'Content-Type': 'application/json'},
+				body: JSON.stringify({name}),
+			});
+			const responseData = await response.json();
+			console.log('responseData', responseData); // TODO logging
+			if (response.ok) {
+				newPersonaName = '';
+				session.update(($session) => ({
+					...$session,
+					personas: [...$session.personas, responseData.persona],
+				}));
+			} else {
+				console.error('response', response); // TODO logging
+				errorMessage =
+					responseData.reason || 'Something went wrong. Maybe check your Internet connection?';
+			}
+		} catch (err) {
+			console.error('err', err); // TODO logging
+			errorMessage = `Something went wrong. Is your Internet connection working? Maybe Felt's server is busted. Please try again!`;
+		} finally {
+			isSubmitting = false;
+		}
+	};
+</script>
+
+<form>
+	<input type="text" bind:value={newPersonaName} bind:this={inputEl} />
+	<button on:click|preventDefault={() => createPersona(newPersonaName)} bind:this={buttonEl}>create
+		persona</button>
+</form>
+
+{#if errorMessage}
+	<div class="error">{errorMessage}</div>
+{/if}
+
+<style>
+	.error {
+		font-weight: bold;
+		color: red;
+	}
+</style>

--- a/src/client/persona/PersonaList.svelte
+++ b/src/client/persona/PersonaList.svelte
@@ -1,0 +1,10 @@
+<script>
+	export let personas;
+</script>
+
+<h2>personas</h2>
+<ul>
+	{#each personas as persona}
+		<li>{persona.name}</li>
+	{/each}
+</ul>

--- a/src/client/session/session.ts
+++ b/src/client/session/session.ts
@@ -1,9 +1,11 @@
 import {AccountModel} from '../../accounts/AccountModel.js';
+import {PersonaModel} from '../../personas/PersonaModel.js';
 
 export type ClientSession = AccountSession | GuestSession;
 
 export interface AccountSession {
 	account: AccountModel;
+	personas: PersonaModel[];
 	isGuest?: false;
 }
 

--- a/src/client/ui/AccountLoginForm.svelte
+++ b/src/client/ui/AccountLoginForm.svelte
@@ -12,7 +12,9 @@
 	// Might want to move it to a store and/or remove for production.
 	const EMAIL_STORAGE_KEY = 'FELT__email';
 	const loadEmail = () => {
-		return typeof localStorage === 'undefined' ? '' : localStorage.getItem(EMAIL_STORAGE_KEY) || '';
+		return (
+			(typeof localStorage !== 'undefined' && localStorage.getItem(EMAIL_STORAGE_KEY)) || 'a@a.a'
+		);
 	};
 	const saveEmail = (email) => {
 		if (typeof localStorage !== 'undefined') localStorage.setItem(EMAIL_STORAGE_KEY, email);

--- a/src/db/Db.ts
+++ b/src/db/Db.ts
@@ -3,6 +3,7 @@ import {Unobtain} from '@feltcoop/gro/dist/utils/createObtainable';
 import {obtainKnex, KnexInstance} from './obtainKnex.js';
 import {AccountsRepo} from '../accounts/AccountsRepo.js';
 import {LoginsRepo} from '../accounts/LoginsRepo.js';
+import {PersonasRepo} from '../personas/PersonasRepo.js';
 
 /*
 
@@ -27,6 +28,7 @@ export class Db {
 		this.repos = {
 			accounts: new AccountsRepo(knex),
 			logins: new LoginsRepo(knex),
+			personas: new PersonasRepo(knex),
 		};
 	}
 
@@ -38,4 +40,5 @@ export class Db {
 interface DbRepos {
 	readonly accounts: AccountsRepo;
 	readonly logins: LoginsRepo;
+	readonly personas: PersonasRepo;
 }

--- a/src/db/loadClientSession.ts
+++ b/src/db/loadClientSession.ts
@@ -1,0 +1,17 @@
+import {AccountSession} from '../client/session/session.js';
+import {unwrap} from '../utils.js';
+import {Db} from '../db/Db.js';
+import {AccountModel} from '../accounts/AccountModel.js';
+
+// TODO should this and `src/client/session` stuff be located in the same place?
+// should that be in `src/session`?
+// This is currently separated because it includes server-only imports.
+// Even though Rollup allows it, I think it's inadvisable
+// to mix server-only concerns into modules imported by the client.
+
+export const loadClientSession = async (db: Db, account: AccountModel): Promise<AccountSession> => {
+	return {
+		account,
+		personas: unwrap(await db.repos.personas.findByAccount(account.id)),
+	};
+};

--- a/src/db/migrations/20200403163837_init.ts
+++ b/src/db/migrations/20200403163837_init.ts
@@ -15,4 +15,18 @@ export const up = async (knex: KnexInstance) => {
 		t.text('secret').index().notNullable();
 		t.text('redirectPath');
 	});
+
+	await knex.schema.createTable('personas', (t) => {
+		t.increments();
+		t.integer('account').unsigned().notNullable();
+		t.foreign('account').references('id').inTable('accounts');
+		// TODO does this need an index for searching duplicate names within each community?
+		// or can we encode this constraint in the database somehow?
+		// I tried to do `t.primary(['account', 'name'])` but got this error:
+		// 		alter table "personas" add constraint "personas_pkey" primary key ("account", "name") - multiple primary keys for table "personas" are not allowed
+		t.text('name').notNullable();
+		// TODO see ActivityStreams icon spec - https://www.w3.org/TR/activitystreams-vocabulary/#dfn-icon
+		// Should we go with that spec and make it a JSON object? Or keep it simple as a url? A foreign key?
+		// t.text('icon').notNullable();
+	});
 };

--- a/src/db/seed.task.ts
+++ b/src/db/seed.task.ts
@@ -1,20 +1,37 @@
 import {Task} from '@feltcoop/gro/dist/task/task.js';
 
-import {obtainKnex} from './obtainKnex.js';
+import {obtainKnex, KnexInstance} from './obtainKnex.js';
 
 export const task: Task = {
 	description: 'seed the database',
 	run: async () => {
 		const [knex, unobtainKnex] = obtainKnex();
 
-		await knex('accounts').insert([
+		await addSeedData(knex);
+
+		unobtainKnex();
+	},
+};
+
+// TODO should seeding use the repos or directly insert documents?
+const addSeedData = async (knex: KnexInstance): Promise<void> => {
+	const accounts = await knex('accounts')
+		.insert([
 			{email: 'a@a.a'},
 			{email: 'b@b.b'},
 			{email: 'c@c.c'},
 			{email: 'd@d.d'},
 			{email: 'e@e.e'},
-		]);
+		])
+		.returning('*');
 
-		unobtainKnex();
-	},
+	await Promise.all(
+		accounts.map(async (account) => {
+			await knex('personas').insert([
+				{name: `p${account.id}a`, account: account.id},
+				{name: `p${account.id}b`, account: account.id},
+				{name: `p${account.id}c`, account: account.id},
+			]);
+		}),
+	);
 };

--- a/src/personas/PersonaModel.ts
+++ b/src/personas/PersonaModel.ts
@@ -1,0 +1,10 @@
+import {ModelId} from '../db/Model.js';
+import {AccountModelId} from '../accounts/AccountModel.js';
+
+export type PersonaModelId = ModelId<PersonaModel>;
+
+export interface PersonaModel {
+	id: PersonaModelId;
+	account: AccountModelId;
+	name: string;
+}

--- a/src/personas/PersonasRepo.test.ts
+++ b/src/personas/PersonasRepo.test.ts
@@ -1,0 +1,121 @@
+import {test, t} from '@feltcoop/gro';
+
+import {PersonasRepo} from './PersonasRepo.js';
+import {getKnex} from '../test.task.js';
+import {PersonaModel} from './PersonaModel.js';
+
+const randomName = () => `persona_name_${Math.random()}`; // TODO clear the db each run?;
+
+test('PersonasRepo', () => {
+	const testAccount = 1; // TODO improve this? pretty hacky but fine for now. global setup to get some test accounts?
+	const testAccount2 = 2;
+	const personasRepo = new PersonasRepo(getKnex());
+	const testName = randomName();
+	const testNameUppercase = testName.toUpperCase();
+	t.isNot(testName, testNameUppercase); // just in case something changes
+	let testPersona: PersonaModel;
+
+	test('create()', async () => {
+		test('creates a persona with a case-insensitive name', async () => {
+			const result = await personasRepo.create({account: testAccount, name: testNameUppercase});
+			t.ok(result.ok);
+			t.is(result.value.name, testName);
+			testPersona = result.value;
+		});
+		test('creates a second persona for the same account', async () => {
+			const name = randomName();
+			const result = await personasRepo.create({account: testAccount, name});
+			t.ok(result.ok);
+			t.is(result.value.name, name);
+		});
+		test('creates a persona for a second account', async () => {
+			const name = randomName();
+			const result = await personasRepo.create({account: testAccount2, name});
+			t.ok(result.ok);
+			t.is(result.value.name, name);
+		});
+		test('creates a second persona for the second account', async () => {
+			const name = randomName();
+			const result = await personasRepo.create({account: testAccount2, name});
+			t.ok(result.ok);
+			t.is(result.value.name, name);
+		});
+		test('fails to create a persona with a duplicate name', async () => {
+			const result = await personasRepo.create({account: testAccount, name: testName});
+			t.ok(!result.ok);
+			t.is(result.type, 'duplicateName');
+		});
+		test('fails to create a persona with a duplicate name with different case', async () => {
+			const result = await personasRepo.create({account: testAccount, name: testNameUppercase});
+			t.ok(!result.ok);
+			t.is(result.type, 'duplicateName');
+		});
+		test('fails to create a persona with an invalid name', async () => {
+			const result = await personasRepo.create({account: testAccount, name: ''});
+			t.ok(!result.ok);
+			t.is(result.type, 'invalidName');
+		});
+		test('errors with an invalid account', async () => {
+			await t.rejects(personasRepo.create({account: -1, name: randomName()}));
+		});
+	});
+
+	test('findById()', async () => {
+		test('finds one by id', async () => {
+			const result = await personasRepo.findById(testPersona.id);
+			t.ok(result.ok);
+			t.equal(result.value, testPersona);
+		});
+		test('fails to find a nonexistent persona', async () => {
+			const result = await personasRepo.findById(-1);
+			t.ok(!result.ok);
+			t.is(result.type, 'noPersonaFound');
+		});
+	});
+
+	test('findByAccountAndName()', async () => {
+		test('finds one by account and name', async () => {
+			const result = await personasRepo.findByAccountAndName(testAccount, testName);
+			t.ok(result.ok);
+			t.equal(result.value, testPersona);
+		});
+		test('finds one by account and name with a different case', async () => {
+			const result = await personasRepo.findByAccountAndName(testAccount, testNameUppercase);
+			t.ok(result.ok);
+			t.equal(result.value, testPersona);
+		});
+		test('fails to find a nonexistent persona', async () => {
+			const result = await personasRepo.findByAccountAndName(testAccount, randomName());
+			t.ok(!result.ok);
+			t.is(result.type, 'noPersonaFound');
+		});
+		test('fails with an invalid name', async () => {
+			const result = await personasRepo.findByAccountAndName(testAccount, '');
+			t.ok(!result.ok);
+			t.is(result.type, 'invalidName');
+		});
+	});
+
+	test('findByAccount()', async () => {
+		test('finds all by account', async () => {
+			const result = await personasRepo.findByAccount(testAccount);
+			t.ok(result.ok);
+			t.ok(result.value.length > 1);
+			for (const persona of result.value) {
+				t.is(persona.account, testAccount);
+			}
+			// query the second test account's personas
+			const result2 = await personasRepo.findByAccount(testAccount2);
+			t.ok(result2.ok);
+			t.ok(result2.value.length > 1);
+			for (const persona of result2.value) {
+				t.is(persona.account, testAccount2);
+			}
+		});
+		test('fails to find with an invalid account', async () => {
+			const result = await personasRepo.findByAccount(-1);
+			t.ok(result.ok);
+			t.is(result.value.length, 0);
+		});
+	});
+});

--- a/src/personas/PersonasRepo.test.ts
+++ b/src/personas/PersonasRepo.test.ts
@@ -7,51 +7,51 @@ import {PersonaModel} from './PersonaModel.js';
 const randomName = () => `persona_name_${Math.random()}`; // TODO clear the db each run?;
 
 test('PersonasRepo', () => {
-	const testAccount = 1; // TODO improve this? pretty hacky but fine for now. global setup to get some test accounts?
+	const testAccount1 = 1; // TODO improve this? pretty hacky but fine for now. global setup to get some test accounts?
 	const testAccount2 = 2;
 	const personasRepo = new PersonasRepo(getKnex());
-	const testName = randomName();
-	const testNameUppercase = testName.toUpperCase();
-	t.isNot(testName, testNameUppercase); // just in case something changes
-	let testPersona: PersonaModel;
+	const testName1a = randomName();
+	const testName1b = randomName();
+	const testName2a = randomName();
+	const testName2b = randomName();
+	const testName1aUppercase = testName1a.toUpperCase();
+	t.isNot(testName1a, testName1aUppercase); // just in case something changes
+	let testPersona1a: PersonaModel;
 
 	test('create()', async () => {
 		test('creates a persona with a case-insensitive name', async () => {
-			const result = await personasRepo.create({account: testAccount, name: testNameUppercase});
+			const result = await personasRepo.create({account: testAccount1, name: testName1aUppercase});
 			t.ok(result.ok);
-			t.is(result.value.name, testName);
-			testPersona = result.value;
+			t.is(result.value.name, testName1a);
+			testPersona1a = result.value;
 		});
 		test('creates a second persona for the same account', async () => {
-			const name = randomName();
-			const result = await personasRepo.create({account: testAccount, name});
+			const result = await personasRepo.create({account: testAccount1, name: testName1b});
 			t.ok(result.ok);
-			t.is(result.value.name, name);
+			t.is(result.value.name, testName1b);
 		});
 		test('creates a persona for a second account', async () => {
-			const name = randomName();
-			const result = await personasRepo.create({account: testAccount2, name});
+			const result = await personasRepo.create({account: testAccount2, name: testName2a});
 			t.ok(result.ok);
-			t.is(result.value.name, name);
+			t.is(result.value.name, testName2a);
 		});
 		test('creates a second persona for the second account', async () => {
-			const name = randomName();
-			const result = await personasRepo.create({account: testAccount2, name});
+			const result = await personasRepo.create({account: testAccount2, name: testName2b});
 			t.ok(result.ok);
-			t.is(result.value.name, name);
+			t.is(result.value.name, testName2b);
 		});
 		test('fails to create a persona with a duplicate name', async () => {
-			const result = await personasRepo.create({account: testAccount, name: testName});
+			const result = await personasRepo.create({account: testAccount1, name: testName1a});
 			t.ok(!result.ok);
 			t.is(result.type, 'duplicateName');
 		});
 		test('fails to create a persona with a duplicate name with different case', async () => {
-			const result = await personasRepo.create({account: testAccount, name: testNameUppercase});
+			const result = await personasRepo.create({account: testAccount1, name: testName1aUppercase});
 			t.ok(!result.ok);
 			t.is(result.type, 'duplicateName');
 		});
 		test('fails to create a persona with an invalid name', async () => {
-			const result = await personasRepo.create({account: testAccount, name: ''});
+			const result = await personasRepo.create({account: testAccount1, name: ''});
 			t.ok(!result.ok);
 			t.is(result.type, 'invalidName');
 		});
@@ -62,9 +62,9 @@ test('PersonasRepo', () => {
 
 	test('findById()', async () => {
 		test('finds one by id', async () => {
-			const result = await personasRepo.findById(testPersona.id);
+			const result = await personasRepo.findById(testPersona1a.id);
 			t.ok(result.ok);
-			t.equal(result.value, testPersona);
+			t.equal(result.value, testPersona1a);
 		});
 		test('fails to find a nonexistent persona', async () => {
 			const result = await personasRepo.findById(-1);
@@ -75,22 +75,22 @@ test('PersonasRepo', () => {
 
 	test('findByAccountAndName()', async () => {
 		test('finds one by account and name', async () => {
-			const result = await personasRepo.findByAccountAndName(testAccount, testName);
+			const result = await personasRepo.findByAccountAndName(testAccount1, testName1a);
 			t.ok(result.ok);
-			t.equal(result.value, testPersona);
+			t.equal(result.value, testPersona1a);
 		});
 		test('finds one by account and name with a different case', async () => {
-			const result = await personasRepo.findByAccountAndName(testAccount, testNameUppercase);
+			const result = await personasRepo.findByAccountAndName(testAccount1, testName1aUppercase);
 			t.ok(result.ok);
-			t.equal(result.value, testPersona);
+			t.equal(result.value, testPersona1a);
 		});
 		test('fails to find a nonexistent persona', async () => {
-			const result = await personasRepo.findByAccountAndName(testAccount, randomName());
+			const result = await personasRepo.findByAccountAndName(testAccount1, randomName());
 			t.ok(!result.ok);
 			t.is(result.type, 'noPersonaFound');
 		});
 		test('fails with an invalid name', async () => {
-			const result = await personasRepo.findByAccountAndName(testAccount, '');
+			const result = await personasRepo.findByAccountAndName(testAccount1, '');
 			t.ok(!result.ok);
 			t.is(result.type, 'invalidName');
 		});
@@ -98,19 +98,28 @@ test('PersonasRepo', () => {
 
 	test('findByAccount()', async () => {
 		test('finds all by account', async () => {
-			const result = await personasRepo.findByAccount(testAccount);
+			const result = await personasRepo.findByAccount(testAccount1);
 			t.ok(result.ok);
 			t.ok(result.value.length > 1);
 			for (const persona of result.value) {
-				t.is(persona.account, testAccount);
+				t.is(persona.account, testAccount1);
 			}
-			// query the second test account's personas
-			const result2 = await personasRepo.findByAccount(testAccount2);
-			t.ok(result2.ok);
-			t.ok(result2.value.length > 1);
-			for (const persona of result2.value) {
+			// TODO we probably want to create a new account every test run and
+			// ensure exactly these 2 persona names are found and no more
+			t.ok(result.value.find((p) => p.name === testName1a));
+			t.ok(result.value.find((p) => p.name === testName1b));
+		});
+		test('finds all for the second account', async () => {
+			const result = await personasRepo.findByAccount(testAccount2);
+			t.ok(result.ok);
+			t.ok(result.value.length > 1);
+			for (const persona of result.value) {
 				t.is(persona.account, testAccount2);
 			}
+			// TODO we probably want to create a new account every test run and
+			// ensure exactly these 2 persona names are found and no more
+			t.ok(result.value.find((p) => p.name === testName2a));
+			t.ok(result.value.find((p) => p.name === testName2b));
 		});
 		test('fails to find with an invalid account', async () => {
 			const result = await personasRepo.findByAccount(-1);

--- a/src/personas/PersonasRepo.ts
+++ b/src/personas/PersonasRepo.ts
@@ -1,0 +1,94 @@
+import {Repo} from '../db/Repo.js';
+import {PersonaModel, PersonaModelId} from './PersonaModel.js';
+import {AccountModelId} from '../accounts/AccountModel.js';
+
+// TODO what is a name?
+// is it a url-friendly slug? or the human-readable title? both?
+// should communities be given control over their url slug directly, decoupled from the name/title?
+// how should we handle case insensitivity in the db? what about special characters like `-` and `_`? other languages?
+// see https://stackoverflow.com/questions/7005302/postgresql-how-to-make-case-insensitive-query
+// Should "name" has uniform semantics (like ActivityStreams properties)
+// but per-table constraints, like length?
+// Should "name" be have its own flavored type? For each table or global?
+const normalizeName = (name: string) => name.toLowerCase();
+const isName = (str: string): boolean => {
+	return typeof str === 'string' && str.length > 0;
+};
+
+export class PersonasRepo extends Repo<PersonaModel> {
+	name = 'personas';
+
+	async create(
+		partialModel: Pick<PersonaModel, 'account' | 'name'>,
+	): Promise<
+		Result<
+			{value: PersonaModel},
+			{type: 'invalidName'; reason: string} | {type: 'duplicateName'; reason: string}
+		>
+	> {
+		const {account} = partialModel; // TODO does this need validation? just let the db throw?
+
+		// TODO formalized normalization + validation
+		const name = normalizeName(partialModel.name); // TODO see name discussion above
+		if (!isName(name)) {
+			return {ok: false, type: 'invalidName', reason: `Invalid name '${name}'.`};
+		}
+
+		// Disallow duplicates with the same name for each account.
+		// Does not rely on database to throw a uniqueness error.
+		// Can we add this constraint to the database?
+		const existingPersona = await this.findByAccountAndName(account, name);
+		if (existingPersona.ok) {
+			return {
+				ok: false,
+				type: 'duplicateName',
+				reason: `Persona already exists with name '${name}'.`,
+			};
+		}
+
+		const value = (await this.query().insert({name, account}).returning('*'))[0];
+		return {ok: true, value};
+	}
+
+	async findById(
+		id: PersonaModelId,
+	): Promise<Result<{value: PersonaModel}, {type: 'noPersonaFound'; reason: string}>> {
+		const value = await this.query().where('id', id).first();
+		return value
+			? {ok: true, value}
+			: {ok: false, type: 'noPersonaFound', reason: `Cannot find persona with id ${id}.`};
+	}
+
+	// Finds a persona for an account by name.
+	async findByAccountAndName(
+		account: AccountModelId,
+		name: string,
+	): Promise<
+		Result<
+			{value: PersonaModel},
+			{type: 'invalidName'; reason: string} | {type: 'noPersonaFound'; reason: string}
+		>
+	> {
+		name = normalizeName(name); // TODO see name discussion above
+		if (!isName(name)) {
+			// TODO formalize validation
+			return {ok: false, type: 'invalidName', reason: `Invalid name '${name}'.`};
+		}
+		const value = await this.query().where({account, name}).first();
+		return value
+			? {ok: true, value}
+			: {
+					ok: false,
+					type: 'noPersonaFound',
+					reason: `Cannot find persona with name '${name}'.`,
+			  };
+	}
+
+	// Finds all personas for an account.
+	async findByAccount(account: AccountModelId): Promise<Result<{value: PersonaModel[]}>> {
+		// TODO the `Result` isn't used here - should we change the code to return `PeronaModel[]`?
+		// or is it likely we'll want to wrap certain errors in the future with a result failure?
+		const value = await this.query().where('account', account);
+		return value ? {ok: true, value} : {ok: false};
+	}
+}

--- a/src/personas/createPersonaMiddleware.ts
+++ b/src/personas/createPersonaMiddleware.ts
@@ -1,0 +1,34 @@
+import {Middleware} from 'polka';
+import send from '@polka/send-type';
+
+import {Server} from '../server/Server.js';
+
+// TODO this really doesn't belong as its own middleware,
+// we probably want a data structure representing our API
+// powered by a single middleware
+
+export const createPersonaMiddleware = (server: Server): Middleware => {
+	return async (req, res) => {
+		console.log('createPersonaMiddleware req.body', req.body!.name); // TODO logging
+		const {name} = req.body!;
+
+		// TODO declarative authorization
+		if (!req.account) {
+			return send(res, 401, {reason: `Please log in`});
+		}
+
+		try {
+			const createPersonaResult = await server.db.repos.personas.create({
+				account: req.account.id,
+				name,
+			});
+			if (createPersonaResult.ok) {
+				return send(res, 200, {persona: createPersonaResult.value});
+			} else {
+				return send(res, 400, {reason: createPersonaResult.reason});
+			}
+		} catch (_err) {
+			return send(res, 500, {reason: 'Unknown error creating persona'});
+		}
+	};
+};

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -4,6 +4,8 @@
 	import SocialLinks from '../client/ui/SocialLinks.svelte';
 	import AccountLoginForm from '../client/ui/AccountLoginForm.svelte';
 	import AccountLogoutForm from '../client/ui/AccountLogoutForm.svelte';
+	import CreatePersona from '../client/persona/CreatePersona.svelte';
+	import PersonaList from '../client/persona/PersonaList.svelte';
 
 	const {session} = stores();
 	$: console.log('$session changed', $session); // TODO logging
@@ -15,15 +17,21 @@
 <div style="max-width: 640px;">
 	<h1>Felt</h1>
 	<small>customizable community tools that feel good</small>
+	<section>
+		{#if $session.account}
+			{$session.account.email}
+			<AccountLogoutForm />
+		{:else}
+			<AccountLoginForm />
+		{/if}
+	</section>
+	{#if $session.account}
+		<section>
+			<CreatePersona {session} />
+			<PersonaList personas={$session.personas} />
+		</section>
+	{/if}
 	<ul>
-		<li>
-			{#if $session.account}
-				{$session.account.email}
-				<AccountLogoutForm />
-			{:else}
-				<AccountLoginForm />
-			{/if}
-		</li>
 		<li>
 			<a href="/about">
 				<span>→ learn about Felt ←</span>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,20 @@
+// TODO this should probably be moved, maybe upstream to Gro -
+// it's a little specialized but not _that_ specialized.
+
+// `unwrap` is a helper for working with result values.
+// In many cases, it should not be used, and instead error conditions should be manually handled,
+// but it's helpful in situations where you want to express, "if this fails, bubble up any error".
+// Generally speaking that means you're not expecting an error to occur.
+export const unwrap = <
+	TValue extends {value: TWrappedValue},
+	TWrappedValue,
+	TError extends {reason?: string}
+>(
+	result: Result<TValue, TError>,
+): TWrappedValue => {
+	if (result.ok) {
+		return result.value;
+	} else {
+		throw Error(result.reason || `Failed to unwrap result with unknown reason`);
+	}
+};

--- a/static/global.css
+++ b/static/global.css
@@ -7,8 +7,8 @@ body {
 	height: 100%;
 	width: 100%;
 	margin: 0;
-	font-family: Roboto, -apple-system, BlinkMacSystemFont, Segoe UI, Oxygen,
-		Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+	font-family: Roboto, -apple-system, BlinkMacSystemFont, Segoe UI, Oxygen, Ubuntu, Cantarell,
+		Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
 	font-size: 14px;
 	line-height: 1.3;
 	color: #333;
@@ -21,6 +21,10 @@ code {
 	background-color: #f0f0f0;
 	padding: 0.2em 0.4em;
 	border-radius: 2px;
+}
+
+section {
+	margin: 30px 0;
 }
 
 @media (min-width: 400px) {


### PR DESCRIPTION
This adds personas to the database and client session data and it adds an API route to create new ones. You should be able to run `gro db/create` which seeds some accounts and personas, and then from the homepage, after logging in you should see the account's personas and add new ones via a form.

The first three commits are from #40 and I'll rebase on master once that's merged.