### PR TITLE
create communities

### DIFF
--- a/src/client/community/CommunityList.svelte
+++ b/src/client/community/CommunityList.svelte
@@ -1,0 +1,10 @@
+<script>
+	export let communities;
+</script>
+
+<h2>communities</h2>
+<ul>
+	{#each communities as community}
+		<li>{community.name}</li>
+	{/each}
+</ul>

--- a/src/client/community/CreateCommunity.svelte
+++ b/src/client/community/CreateCommunity.svelte
@@ -1,0 +1,73 @@
+<script>
+	export let session;
+
+	let newCommunityName = 'community_' + ((Math.random() * 1000000) | 0);
+
+	let errorMessage = null;
+	let isSubmitting = false;
+	let buttonEl;
+	let inputEl;
+
+	const isName = (str) => str.length > 0; // TODO
+
+	const createCommunity = async (name) => {
+		if (!name) {
+			inputEl.focus();
+			errorMessage = 'please enter a community name';
+			return;
+		}
+		if (!isName(name)) {
+			inputEl.focus();
+			errorMessage = 'please enter a valid community name';
+			return;
+		}
+		buttonEl.focus();
+		isSubmitting = true;
+		errorMessage = '';
+		try {
+			// TODO '/api/v1/communities/create' ?
+			const response = await fetch('/api/v1/communities', {
+				method: 'POST',
+				headers: {'Content-Type': 'application/json'},
+				body: JSON.stringify({name}),
+			});
+			const responseData = await response.json();
+			console.log('responseData', responseData); // TODO logging
+			if (response.ok) {
+				newCommunityName = '';
+				session.update(($session) => ({
+					...$session,
+					communities: [...$session.communities, responseData.community],
+				}));
+			} else {
+				console.error('response', response); // TODO logging
+				errorMessage =
+					responseData.reason || 'Something went wrong. Maybe check your Internet connection?';
+			}
+		} catch (err) {
+			console.error('err', err); // TODO logging
+			errorMessage = `Something went wrong. Is your Internet connection working? Maybe Felt's server is busted. Please try again!`;
+		} finally {
+			isSubmitting = false;
+		}
+	};
+</script>
+
+<form>
+	<input type="text" bind:value={newCommunityName} bind:this={inputEl} />
+	<button
+		on:click|preventDefault={() => createCommunity(newCommunityName)}
+		bind:this={buttonEl}
+	>create community</button>
+</form>
+
+{#if errorMessage}
+	<div class="error">{errorMessage}</div>
+{/if}
+
+<style>
+	.error {
+		font-weight: bold;
+		color: red;
+	}
+</style>

--- a/src/client/session/session.ts
+++ b/src/client/session/session.ts
@@ -1,11 +1,13 @@
 import {AccountModel} from '../../accounts/AccountModel.js';
 import {PersonaModel} from '../../personas/PersonaModel.js';
+import {CommunityModel} from '../../communities/CommunityModel.js';
 
 export type ClientSession = AccountSession | GuestSession;
 
 export interface AccountSession {
 	account: AccountModel;
 	personas: PersonaModel[];
+	communities: CommunityModel[];
 	isGuest?: false;
 }
 

--- a/src/communities/CommunitiesRepo.test.ts
+++ b/src/communities/CommunitiesRepo.test.ts
@@ -1,0 +1,73 @@
+import {test, t} from '@feltcoop/gro';
+
+import {CommunitiesRepo} from './CommunitiesRepo.js';
+import {getKnex} from '../test.task.js';
+import {CommunityModel} from './CommunityModel.js';
+
+test('CommunitiesRepo', () => {
+	const communitiesRepo = new CommunitiesRepo(getKnex());
+	const testName = `community_name${Math.random()}`;
+	const testNameUppercase = testName.toUpperCase();
+	t.isNot(testName, testNameUppercase); // just in case something changes
+	let testCommunity: CommunityModel;
+
+	test('create()', async () => {
+		test('creates a community with a case-insensitive name', async () => {
+			const result = await communitiesRepo.create({name: testNameUppercase});
+			t.ok(result.ok);
+			t.is(result.value.name, testName);
+			testCommunity = result.value;
+		});
+		test('fails to create a community with a duplicate name', async () => {
+			const result = await communitiesRepo.create({name: testName});
+			t.ok(!result.ok);
+			t.is(result.type, 'duplicateName');
+		});
+		test('fails to create a community with a duplicate name with different case', async () => {
+			const result = await communitiesRepo.create({name: testNameUppercase});
+			t.ok(!result.ok);
+			t.is(result.type, 'duplicateName');
+		});
+		test('fails to create a community with an empty name', async () => {
+			const result = await communitiesRepo.create({name: ''});
+			t.ok(!result.ok);
+			t.is(result.type, 'invalidName');
+		});
+	});
+
+	test('findById()', async () => {
+		test('finds one by id', async () => {
+			const result = await communitiesRepo.findById(testCommunity.id);
+			t.ok(result.ok);
+			t.equal(result.value, testCommunity);
+		});
+		test('fails to find a nonexistent community', async () => {
+			const result = await communitiesRepo.findById(-1);
+			t.ok(!result.ok);
+			t.is(result.type, 'noCommunityFound');
+		});
+	});
+
+	test('findByName()', async () => {
+		test('finds one by name', async () => {
+			const result = await communitiesRepo.findByName(testCommunity.name);
+			t.ok(result.ok);
+			t.equal(result.value, testCommunity);
+		});
+		test('finds one by name with a different case', async () => {
+			const result = await communitiesRepo.findByName(testNameUppercase);
+			t.ok(result.ok);
+			t.equal(result.value, testCommunity);
+		});
+		test('fails to find a nonexistent community', async () => {
+			const result = await communitiesRepo.findByName(`not_in_db`);
+			t.ok(!result.ok);
+			t.is(result.type, 'noCommunityFound');
+		});
+		test('fails with an invalid name', async () => {
+			const result = await communitiesRepo.findByName('');
+			t.ok(!result.ok);
+			t.is(result.type, 'invalidName');
+		});
+	});
+});

--- a/src/communities/CommunitiesRepo.ts
+++ b/src/communities/CommunitiesRepo.ts
@@ -1,0 +1,74 @@
+import {Repo} from '../db/Repo.js';
+import {CommunityModel, CommunityModelId} from './CommunityModel.js';
+
+// TODO see discussion of "name" property in ../personas/PersonasRepo.ts
+const normalizeName = (name: string) => name.toLowerCase();
+const isName = (str: string): boolean => {
+	return typeof str === 'string' && str.length > 0;
+};
+
+export class CommunitiesRepo extends Repo<CommunityModel> {
+	name = 'communities';
+
+	// TODO do we want to store the creator's account as well? or is the default admin role enough?
+	async create(
+		partialModel: Pick<CommunityModel, 'name'>,
+	): Promise<
+		Result<
+			{value: CommunityModel},
+			{type: 'invalidName'; reason: string} | {type: 'duplicateName'; reason: string}
+		>
+	> {
+		// TODO formalized normalization + validation
+		const name = normalizeName(partialModel.name);
+		if (!isName(name)) {
+			return {ok: false, type: 'invalidName', reason: `Invalid name '${name}'.`};
+		}
+
+		// Disallow duplicates with the same name.
+		// Does not rely on database to throw a uniqueness error.
+		const existingCommunity = await this.findByName(name);
+		if (existingCommunity.ok) {
+			return {
+				ok: false,
+				type: 'duplicateName',
+				reason: `Community already exists with name '${name}'.`,
+			};
+		}
+
+		const value = (await this.query().insert({name}).returning('*'))[0];
+		return {ok: true, value};
+	}
+
+	async findById(
+		id: CommunityModelId,
+	): Promise<Result<{value: CommunityModel}, {type: 'noCommunityFound'; reason: string}>> {
+		const value = await this.query().where('id', id).first();
+		return value
+			? {ok: true, value}
+			: {ok: false, type: 'noCommunityFound', reason: `Cannot find community with id ${id}.`};
+	}
+
+	async findByName(
+		name: string,
+	): Promise<
+		Result<
+			{value: CommunityModel},
+			{type: 'invalidName'; reason: string} | {type: 'noCommunityFound'; reason: string}
+		>
+	> {
+		name = normalizeName(name); // TODO see name discussion at top of file
+		if (!isName(name)) {
+			// TODO formalize validation
+			return {ok: false, type: 'invalidName', reason: `Invalid name '${name}'.`};
+		}
+		const value = await this.query().where('name', name).first();
+		return value
+			? {ok: true, value}
+			: {
+					ok: false,
+					type: 'noCommunityFound',
+					reason: `Cannot find community with name '${name}'.`,
+			  };
+	}
+}

--- a/src/communities/CommunityModel.ts
+++ b/src/communities/CommunityModel.ts
@@ -1,0 +1,8 @@
+import {ModelId} from '../db/Model.js';
+
+export type CommunityModelId = ModelId<CommunityModel>;
+
+export interface CommunityModel {
+	id: CommunityModelId;
+	name: string;
+}

--- a/src/communities/createCommunityMiddleware.ts
+++ b/src/communities/createCommunityMiddleware.ts
@@ -1,0 +1,31 @@
+import {Middleware} from 'polka';
+import send from '@polka/send-type';
+
+import {Server} from '../server/Server.js';
+
+// TODO this really doesn't belong as its own middleware,
+// we probably want a data structure representing our API
+// powered by a single middleware
+
+export const createCommunityMiddleware = (server: Server): Middleware => {
+	return async (req, res) => {
+		console.log('createCommunityMiddleware req.body', req.body!.name); // TODO logging
+		const {name} = req.body!;
+
+		// TODO declarative authorization
+		if (!req.account) {
+			return send(res, 401, {reason: `Please log in`});
+		}
+
+		try {
+			const createCommunityResult = await server.db.repos.communities.create({name});
+			if (createCommunityResult.ok) {
+				return send(res, 200, {community: createCommunityResult.value});
+			} else {
+				return send(res, 400, {reason: createCommunityResult.reason});
+			}
+		} catch (_err) {
+			return send(res, 500, {reason: 'Unknown error creating community'});
+		}
+	};
+};

--- a/src/db/Db.ts
+++ b/src/db/Db.ts
@@ -4,6 +4,7 @@ import {obtainKnex, KnexInstance} from './obtainKnex.js';
 import {AccountsRepo} from '../accounts/AccountsRepo.js';
 import {LoginsRepo} from '../accounts/LoginsRepo.js';
 import {PersonasRepo} from '../personas/PersonasRepo.js';
+import {CommunitiesRepo} from '../communities/CommunitiesRepo.js';
 
 /*
 
@@ -29,6 +30,7 @@ export class Db {
 			accounts: new AccountsRepo(knex),
 			logins: new LoginsRepo(knex),
 			personas: new PersonasRepo(knex),
+			communities: new CommunitiesRepo(knex),
 		};
 	}
 
@@ -41,4 +43,5 @@ interface DbRepos {
 	readonly accounts: AccountsRepo;
 	readonly logins: LoginsRepo;
 	readonly personas: PersonasRepo;
+	readonly communities: CommunitiesRepo;
 }

--- a/src/db/loadClientSession.ts
+++ b/src/db/loadClientSession.ts
@@ -13,5 +13,6 @@ export const loadClientSession = async (db: Db, account: AccountModel): Promise<
 	return {
 		account,
 		personas: unwrap(await db.repos.personas.findByAccount(account.id)),
+		communities: [], // TODO query communities by persona roles once they're implemented
 	};
 };

--- a/src/db/migrations/20200403163837_init.ts
+++ b/src/db/migrations/20200403163837_init.ts
@@ -16,17 +16,21 @@ export const up = async (knex: KnexInstance) => {
 		t.text('redirectPath');
 	});
 
+	// TODO review indexes on these new tables
+
 	await knex.schema.createTable('personas', (t) => {
 		t.increments();
 		t.integer('account').unsigned().notNullable();
 		t.foreign('account').references('id').inTable('accounts');
-		// TODO does this need an index for searching duplicate names within each community?
-		// or can we encode this constraint in the database somehow?
-		// I tried to do `t.primary(['account', 'name'])` but got this error:
-		// 		alter table "personas" add constraint "personas_pkey" primary key ("account", "name") - multiple primary keys for table "personas" are not allowed
-		t.text('name').notNullable();
+		t.text('name').notNullable(); // TODO index? depends on final design
 		// TODO see ActivityStreams icon spec - https://www.w3.org/TR/activitystreams-vocabulary/#dfn-icon
 		// Should we go with that spec and make it a JSON object? Or keep it simple as a url? A foreign key?
 		// t.text('icon').notNullable();
+	});
+
+	await knex.schema.createTable('communities', (t) => {
+		t.increments();
+		t.text('name').index().notNullable().unique();
+		// t.text('icon').notNullable(); // see above in personas
 	});
 };

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -6,6 +6,8 @@
 	import AccountLogoutForm from '../client/ui/AccountLogoutForm.svelte';
 	import CreatePersona from '../client/persona/CreatePersona.svelte';
 	import PersonaList from '../client/persona/PersonaList.svelte';
+	import CreateCommunity from '../client/community/CreateCommunity.svelte';
+	import CommunityList from '../client/community/CommunityList.svelte';
 
 	const {session} = stores();
 	$: console.log('$session changed', $session); // TODO logging
@@ -29,6 +31,10 @@
 		<section>
 			<CreatePersona {session} />
 			<PersonaList personas={$session.personas} />
+		</section>
+		<section>
+			<CreateCommunity {session} />
+			<CommunityList communities={$session.communities} />
 		</section>
 	{/if}
 	<ul>

--- a/src/server/Server.ts
+++ b/src/server/Server.ts
@@ -16,6 +16,7 @@ import {getEnv} from '../project/env.js';
 import {loginWithSecretMiddleware} from '../accounts/loginWithSecretMiddleware.js';
 import {FeltConfig} from '../project/config.js';
 import {createPersonaMiddleware} from '../personas/createPersonaMiddleware.js';
+import {createCommunityMiddleware} from '../communities/createCommunityMiddleware.js';
 
 const {NODE_ENV} = getEnv();
 const __DEV__ = NODE_ENV === 'development'; // TODO replace in build step
@@ -54,6 +55,7 @@ export class Server {
 			.post('/api/v1/accounts/login', accountLoginMiddleware(this))
 			.post('/api/v1/accounts/logout', accountLogoutMiddleware(this))
 			.post('/api/v1/personas', createPersonaMiddleware(this)) // TODO declarative resource API
+			.post('/api/v1/communities', createCommunityMiddleware(this)) // TODO declarative resource API
 			.get('/api/v1/logins/:secret', loginWithSecretMiddleware(this))
 			.use(
 				sapper.middleware({


### PR DESCRIPTION
This is the next smallest chunk I could isolate in a PR. There's missing functionality in that [it doesn't query the user's communities when the session is loaded](https://github.com/feltcoop/felt/compare/communities?expand=1#diff-1aa20edcfd3d838e8ac59835d495b2f9). We'll fix that once we add roles in the next PR. 

You should be able to create communities from the home page and they'll appear in a list and be saved to the database. The client won't see them on refresh yet though.