### PR TITLE
update gro and migrate to swc compiler in dev mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,9 +31,9 @@
       }
     },
     "@feltcoop/gro": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.3.0.tgz",
-      "integrity": "sha512-VazcrykhUsQBYzW4AtdxVlU9CK4B5Rsz2YO3Dh3p9tB0XScOnpv2uVwAFbAnE189m7ha7lRLrGwGPrEdEM331w==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.4.0.tgz",
+      "integrity": "sha512-fcgje81Y2favrbMxEo3Irfpf8is1Vz7LqVewFrwXkApX8ll8JeUN3ObIFIqVGA3fJyZUe3COT76xfH78KRhi9g==",
       "requires": {
         "@lukeed/uuid": "^1.0.1",
         "@rollup/plugin-commonjs": "^15.0.0",
@@ -66,38 +66,15 @@
           "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.45.tgz",
           "integrity": "sha512-jnqIUKDUqJbDIUxm0Uj7bnlMnRm1T/eZ9N+AVMqhPgzrba2GhGG5o/jCTwmdPK709nEZsGoMzXEDUjcXHa3W0g=="
         },
-        "@types/fs-extra": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.1.tgz",
-          "integrity": "sha512-B42Sxuaz09MhC3DDeW5kubRcQ5by4iuVQ0cRRWM2lggLzAa/KVom0Aft/208NgMvNQQZ86s5rVcqDdn/SH0/mg==",
-          "requires": {
-            "@types/node": "*"
-          }
-        },
         "@types/node": {
-          "version": "12.12.56",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.56.tgz",
-          "integrity": "sha512-8OdIupOIZtmObR13fvGyTvpcuzKmMugkATeVcfNwCjGtHxhjEKmOvLqXwR8U9VOtNnZ4EXaSfNiLVsPinaCXkQ=="
+          "version": "12.12.62",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.62.tgz",
+          "integrity": "sha512-qAfo81CsD7yQIM9mVyh6B/U47li5g7cfpVQEDMfQeF8pSZVwzbhwU3crc0qG4DmpsebpJPR49AKOExQyJ05Cpg=="
         },
         "estree-walker": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.1.tgz",
           "integrity": "sha512-tF0hv+Yi2Ot1cwj9eYHtxC0jB9bmjacjQs6ZBTj82H8JwUywFuc+7E83NWfNMwHXZc11mjfFcVXPe9gEP4B8dg=="
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        },
-        "terser": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/terser/-/terser-5.3.1.tgz",
-          "integrity": "sha512-yD80f4hdwCWTH5mojzxe1q8bN1oJbsK/vfJGLcPZM/fl+/jItIVNKhFIHqqR71OipFWMLgj3Kc+GIp6CeIqfnA==",
-          "requires": {
-            "commander": "^2.20.0",
-            "source-map": "~0.6.1",
-            "source-map-support": "~0.5.12"
-          }
         }
       }
     },
@@ -105,6 +82,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@lukeed/uuid/-/uuid-1.0.1.tgz",
       "integrity": "sha512-shtopUGL/WuVicOTppRGDb2he9aGp+OF5EB11Xsbe3K4W6qN7HtK3F+ayNxcfbrG/SSL/Z9B+Xrb0Foz9x83gw=="
+    },
+    "@node-rs/helper": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/helper/-/helper-0.4.0.tgz",
+      "integrity": "sha512-fSyHEXmlt/FueKqAYiGFCnkohnQBMQwUr6VYPeZEeVBAzQzhioS1WaRe2fSpOuRKIimCQEvxhQ6fwsYxYakfGA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.0.1"
+      }
     },
     "@polka/send-type": {
       "version": "0.5.2",
@@ -196,6 +182,39 @@
         "picomatch": "^2.2.2"
       }
     },
+    "@swc/core": {
+      "version": "1.2.32",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.2.32.tgz",
+      "integrity": "sha512-1sPPePkaoyEg8SAN3DZDxZZwqXb/yy8LENGLniNs7VDN4BVXcw0XquoctV5dv6ZzEzLZoW842M11igg+OxKVyQ==",
+      "dev": true,
+      "requires": {
+        "@node-rs/helper": "^0.4.0",
+        "@swc/core-darwin": "^1.2.32",
+        "@swc/core-linux": "^1.2.32",
+        "@swc/core-win32": "^1.2.32"
+      }
+    },
+    "@swc/core-darwin": {
+      "version": "1.2.32",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin/-/core-darwin-1.2.32.tgz",
+      "integrity": "sha512-1gUUTA1KE8trm4fB7OgUdunojqOKyNaJDtOffcOeVczfM81wBGaDXsO+6pTpza/9eS/mQV5FkhaO/UyMZ32rGw==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-linux": {
+      "version": "1.2.32",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux/-/core-linux-1.2.32.tgz",
+      "integrity": "sha512-a43TPRQTXdXRi7zfuXnl2l21+Gm6jxETPZYR/JH/T9ee1vpftL73jfqTbHZl3QQXv6Prh09fPcakoMPmBgGTBA==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-win32": {
+      "version": "1.2.32",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32/-/core-win32-1.2.32.tgz",
+      "integrity": "sha512-xVFTzgd7W9QK4eb7nW0Px96ahGswNw2SIl15NHJnAJgqeXMQFJ/iJEgMi+kvf8kCcjU0kwEBotAFXZSjHalEag==",
+      "dev": true,
+      "optional": true
+    },
     "@types/body-parser": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
@@ -269,6 +288,14 @@
         "@types/node": "*",
         "@types/qs": "*",
         "@types/range-parser": "*"
+      }
+    },
+    "@types/fs-extra": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.1.tgz",
+      "integrity": "sha512-B42Sxuaz09MhC3DDeW5kubRcQ5by4iuVQ0cRRWM2lggLzAa/KVom0Aft/208NgMvNQQZ86s5rVcqDdn/SH0/mg==",
+      "requires": {
+        "@types/node": "*"
       }
     },
     "@types/keygrip": {
@@ -2365,7 +2392,6 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.3.1.tgz",
       "integrity": "sha512-yD80f4hdwCWTH5mojzxe1q8bN1oJbsK/vfJGLcPZM/fl+/jItIVNKhFIHqqR71OipFWMLgj3Kc+GIp6CeIqfnA==",
-      "dev": true,
       "requires": {
         "commander": "^2.20.0",
         "source-map": "~0.6.1",
@@ -2375,8 +2401,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@rollup/plugin-commonjs": "^15.0.0",
     "@rollup/plugin-node-resolve": "^9.0.0",
     "@rollup/plugin-replace": "^2.3.3",
+    "@swc/core": "^1.2.32",
     "@types/body-parser": "^1.19.0",
     "@types/compression": "^1.7.0",
     "@types/cookie-session": "^2.0.41",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "gro test"
   },
   "dependencies": {
-    "@feltcoop/gro": "^0.3.0",
+    "@feltcoop/gro": "^0.4.0",
     "@polka/send-type": "^0.5.2",
     "body-parser": "^1.19.0",
     "compression": "^1.7.4",

--- a/src/build.task.ts
+++ b/src/build.task.ts
@@ -15,8 +15,6 @@ perhaps using completely different tools to improve the dev experience.
 export const task: Task = {
 	description: 'builds everything for production',
 	run: async ({log, invokeTask}): Promise<void> => {
-		// TODO I think this is broken
-		console.log('build process.env.NODE_ENV', process.env.NODE_ENV);
 		await invokeTask('compile');
 		await copyIgnoredBuildFiles(log, false);
 

--- a/src/build.task.ts
+++ b/src/build.task.ts
@@ -14,9 +14,10 @@ perhaps using completely different tools to improve the dev experience.
 */
 export const task: Task = {
 	description: 'builds everything for production',
-	run: async ({log}): Promise<void> => {
-		log.info('compiling TypeScript');
-		await spawnProcess('node_modules/.bin/tsc');
+	run: async ({log, invokeTask}): Promise<void> => {
+		// TODO I think this is broken
+		console.log('build process.env.NODE_ENV', process.env.NODE_ENV);
+		await invokeTask('compile');
 		await copyIgnoredBuildFiles(log, false);
 
 		log.info('building sapper');

--- a/src/dev.task.ts
+++ b/src/dev.task.ts
@@ -1,5 +1,6 @@
 import {Task} from '@feltcoop/gro';
 import {spawnProcess} from '@feltcoop/gro/dist/utils/process.js';
+import {CachingCompiler} from '@feltcoop/gro/dist/compile/CachingCompiler.js';
 
 import {copyIgnoredBuildFiles} from './project/dev/copyIgnoredBuildFiles.js';
 
@@ -20,10 +21,11 @@ to take advantage of tools that provide big dev-time benefits.
 */
 export const task: Task = {
 	description: 'builds the project for development and watches for changes',
-	run: async ({log}): Promise<void> => {
-		log.info('compiling TypeScript');
-		await spawnProcess('node_modules/.bin/tsc');
+	run: async ({log, invokeTask}): Promise<void> => {
+		await invokeTask('compile');
 		await copyIgnoredBuildFiles(log, true);
+
+		const cachingCompiler = new CachingCompiler();
 
 		log.info('starting Sapper and the TypeScript compiler in watch mode');
 		await Promise.all([
@@ -36,7 +38,7 @@ export const task: Task = {
 				'--output',
 				'build/node_modules/@sapper',
 			]),
-			spawnProcess('node_modules/.bin/tsc', ['-w', '--preserveWatchOutput']),
+			cachingCompiler.init(),
 		]);
 	},
 };

--- a/src/dev.task.ts
+++ b/src/dev.task.ts
@@ -7,7 +7,7 @@ import {copyIgnoredBuildFiles} from './project/dev/copyIgnoredBuildFiles.js';
 
 /*
 
-Felt's build process currently composes TypeScript's compiler,
+Felt's build process currently composes a TypeScript compiler using `swc`,
 Sapper, and a small utility to glue them together via the `build/` directory.
 
 TypeScript is compiled to `build/`,

--- a/src/dev.task.ts
+++ b/src/dev.task.ts
@@ -4,7 +4,6 @@ import {CachingCompiler} from '@feltcoop/gro/dist/compile/CachingCompiler.js';
 import {createCompileFile} from '@feltcoop/gro/dist/compile/compileFile.js';
 
 import {copyIgnoredBuildFiles} from './project/dev/copyIgnoredBuildFiles.js';
-import {getEnv} from './project/env.js';
 
 /*
 
@@ -24,13 +23,10 @@ to take advantage of tools that provide big dev-time benefits.
 export const task: Task = {
 	description: 'builds the project for development and watches for changes',
 	run: async ({log, invokeTask}): Promise<void> => {
-		const {NODE_ENV} = getEnv();
-		const dev = NODE_ENV === 'development';
-
 		await invokeTask('compile');
 		await copyIgnoredBuildFiles(log, true);
 
-		const cachingCompiler = new CachingCompiler({compileFile: createCompileFile({dev, log})});
+		const cachingCompiler = new CachingCompiler({compileFile: createCompileFile(log)});
 
 		log.info('starting Sapper and the TypeScript compiler in watch mode');
 		await Promise.all([

--- a/src/dev.task.ts
+++ b/src/dev.task.ts
@@ -4,6 +4,7 @@ import {CachingCompiler} from '@feltcoop/gro/dist/compile/CachingCompiler.js';
 import {createCompileFile} from '@feltcoop/gro/dist/compile/compileFile.js';
 
 import {copyIgnoredBuildFiles} from './project/dev/copyIgnoredBuildFiles.js';
+import {getEnv} from './project/env.js';
 
 /*
 
@@ -23,10 +24,13 @@ to take advantage of tools that provide big dev-time benefits.
 export const task: Task = {
 	description: 'builds the project for development and watches for changes',
 	run: async ({log, invokeTask}): Promise<void> => {
+		const {NODE_ENV} = getEnv();
+		const dev = NODE_ENV === 'development';
+
 		await invokeTask('compile');
 		await copyIgnoredBuildFiles(log, true);
 
-		const cachingCompiler = new CachingCompiler({compileFile: createCompileFile(log)});
+		const cachingCompiler = new CachingCompiler({compileFile: createCompileFile({dev, log})});
 
 		log.info('starting Sapper and the TypeScript compiler in watch mode');
 		await Promise.all([

--- a/src/dev.task.ts
+++ b/src/dev.task.ts
@@ -1,6 +1,7 @@
 import {Task} from '@feltcoop/gro';
 import {spawnProcess} from '@feltcoop/gro/dist/utils/process.js';
 import {CachingCompiler} from '@feltcoop/gro/dist/compile/CachingCompiler.js';
+import {createCompileFile} from '@feltcoop/gro/dist/compile/compileFile.js';
 
 import {copyIgnoredBuildFiles} from './project/dev/copyIgnoredBuildFiles.js';
 
@@ -25,7 +26,7 @@ export const task: Task = {
 		await invokeTask('compile');
 		await copyIgnoredBuildFiles(log, true);
 
-		const cachingCompiler = new CachingCompiler();
+		const cachingCompiler = new CachingCompiler({compileFile: createCompileFile(log)});
 
 		log.info('starting Sapper and the TypeScript compiler in watch mode');
 		await Promise.all([

--- a/src/reset.task.ts
+++ b/src/reset.task.ts
@@ -10,9 +10,7 @@ export const task: Task = {
 		await spawnProcess('npm', ['install']);
 
 		// rebuild everything
-		await invokeTask('clean');
-		log.info('compiling TypeScript');
-		await spawnProcess('node_modules/.bin/tsc');
+		await invokeTask('compile');
 		await copyIgnoredBuildFiles(log, false);
 
 		// set up the database, clearing all data and running all migrations

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
 
   "compilerOptions": {
     // Main options
-    "target": "es2018", // Specify ECMAScript target version: 'es3' (default), 'es5', 'es2015', 'es2016', 'es2017','es2018' or 'esnext'.
+    "target": "es2019", // Specify ECMAScript target version: 'es3' (default), 'es5', 'es2015', 'es2016', 'es2017','es2018' or 'esnext'.
     "module": "esnext", // Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'.
     "lib": ["esnext", "dom"], // Specify library files to be included in the compilation.
     // "allowJs": false, // Allow javascript files to be compiled.
@@ -73,7 +73,7 @@
     // "declarationMap": false, // Generates a sourcemap for each corresponding '.d.ts' file.
     // "emitBOM": false, // Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files.
     // "emitDeclarationOnly": false, // Only emit ‘.d.ts’ declaration files.
-    "importHelpers": true // Import emit helpers from 'tslib'.
+    "importHelpers": true, // Import emit helpers from 'tslib'.
     // "newLine": "LF", // Use the specified end of line sequence to be used when emitting files: "crlf" (windows) or "lf" (unix).”
     // "noEmit": true, // Do not emit outputs.
     // "noEmitHelpers": false, // Do not generate custom helper functions like __extends in compiled output.
@@ -86,7 +86,8 @@
     // "emitDecoratorMetadata": true, // Enables experimental support for emitting type metadata for decorators.
 
     // Source map options
-    // "sourceMap": false, // Generates corresponding '.map' file.
+    // TODO enable after removing Sapper
+    "sourceMap": false // Generates corresponding '.map' file.
     // "sourceRoot": "", // Specify the location where debugger should locate TypeScript files instead of source locations.
     // "mapRoot": "", // Specify the location where debugger should locate map files instead of generated locations.
     // "inlineSourceMap": true, // Emit a single file with source maps instead of having a separate file.


### PR DESCRIPTION
This updates to version 0.4 of Gro and changes over from the TypeScript compiler to [`swc`](https://github.com/swc-project/swc) in development. It's about 100 times faster on my machine (in parallel, 20x serial) and has a stable-enough future in my estimation because it's been adopted by [Deno](https://github.com/denoland/deno), whose community is robust enough to bet on by proxy. (it has corporate backing, not just hobbyists) If they move to something else, we can always follow with little effort.

I evaluated [`esbuild`](https://github.com/evanw/esbuild) against `swc` but it currently does an unavoidable optimization pass that makes it incompatible with preprocessing TypeScript in Svelte files.

This PR changes the JS version target to `es2019` which should be safe enough to target on modern browsers. If we run into issues we can avoid those features, polyfill, or downcompile. The reason I bumped the version is that `swc`'s downcompiled helpers are currently not building with Rollup. It might be a super simple fix but I just didn't want to spend any time on it.

Source maps are disabled because Sapper breaks with them with our current ducktaped Sapper+TypeScript integration. We'll drop Sapper and turn source maps back on after the first milestone.