### PR TITLE
add roles

### DIFF
--- a/src/communities/CommunityModel.ts
+++ b/src/communities/CommunityModel.ts
@@ -4,5 +4,5 @@ export type CommunityModelId = ModelId<CommunityModel>;
 
 export interface CommunityModel {
 	id: CommunityModelId;
-	name: string;
+	name: string; // TODO flavored type?
 }

--- a/src/communities/CommunityRoleModel.ts
+++ b/src/communities/CommunityRoleModel.ts
@@ -1,0 +1,11 @@
+import {ModelId} from '../db/Model.js';
+import {CommunityModelId} from './CommunityModel.js';
+
+export type CommunityRoleModelId = ModelId<CommunityRoleModel>;
+
+export interface CommunityRoleModel {
+	id: CommunityRoleModelId;
+	community: CommunityModelId;
+	name: string;
+	permissions: any; // TODO  !!!!!!!!  !!!!!!!!
+}

--- a/src/communities/CommunityRolesRepo.test.ts
+++ b/src/communities/CommunityRolesRepo.test.ts
@@ -1,0 +1,150 @@
+import {test, t} from '@feltcoop/gro';
+
+import {CommunityRolesRepo} from './CommunityRolesRepo.js';
+import {getKnex} from '../test.task.js';
+import {CommunityRoleModel} from './CommunityRoleModel.js';
+
+const randomName = () => `community_role_name_${Math.random()}`; // TODO clear the db each run?;
+
+test('CommunityRolesRepo', () => {
+	const testCommunity = 1; // TODO improve this? pretty hacky but fine for now. global setup to get some test communitys?
+	const testCommunity2 = 2;
+	const communityRolesRepo = new CommunityRolesRepo(getKnex());
+	const testName = randomName();
+	const testNameUppercase = testName.toUpperCase();
+	t.isNot(testName, testNameUppercase); // just in case something changes
+	let testCommunityRole: CommunityRoleModel;
+
+	test('create()', async () => {
+		test('creates a communityRole with a case-insensitive name', async () => {
+			const result = await communityRolesRepo.create({
+				community: testCommunity,
+				name: testNameUppercase,
+			});
+			t.ok(result.ok);
+			t.is(result.value.community, testCommunity);
+			t.is(result.value.name, testName);
+			testCommunityRole = result.value;
+		});
+		test('creates a second communityRole for the same community', async () => {
+			const name = randomName();
+			const result = await communityRolesRepo.create({community: testCommunity, name});
+			t.ok(result.ok);
+			t.is(result.value.community, testCommunity);
+			t.is(result.value.name, name);
+		});
+		test('creates a communityRole for a second community', async () => {
+			const name = randomName();
+			const result = await communityRolesRepo.create({community: testCommunity2, name});
+			t.ok(result.ok);
+			t.is(result.value.community, testCommunity2);
+			t.is(result.value.name, name);
+		});
+		test('creates a second communityRole for the second community', async () => {
+			const name = randomName();
+			const result = await communityRolesRepo.create({community: testCommunity2, name});
+			t.ok(result.ok);
+			t.is(result.value.community, testCommunity2);
+			t.is(result.value.name, name);
+		});
+		test('fails to create a communityRole with a duplicate name', async () => {
+			const result = await communityRolesRepo.create({community: testCommunity, name: testName});
+			t.ok(!result.ok);
+			t.is(result.type, 'duplicate');
+		});
+		test('fails to create a communityRole with a duplicate name with different case', async () => {
+			const result = await communityRolesRepo.create({
+				community: testCommunity,
+				name: testNameUppercase,
+			});
+			t.ok(!result.ok);
+			t.is(result.type, 'duplicate');
+		});
+		test('fails to create a communityRole with an invalid community', async () => {
+			await t.rejects(communityRolesRepo.create({community: -1, name: randomName()}));
+		});
+		test('fails to create a communityRole with an empty name', async () => {
+			const result = await communityRolesRepo.create({community: testCommunity, name: ''});
+			t.ok(!result.ok);
+			t.is(result.type, 'invalidName');
+		});
+		test('fails to create a communityRole with an invalid name', async () => {
+			const result = await communityRolesRepo.create({community: testCommunity, name: '1'});
+			t.ok(!result.ok);
+			t.is(result.type, 'invalidName');
+		});
+	});
+
+	test('findById()', async () => {
+		test('finds one by id', async () => {
+			const result = await communityRolesRepo.findById(testCommunityRole.id);
+			t.ok(result.ok);
+			t.equal(result.value, testCommunityRole);
+		});
+		test('fails to find a nonexistent communityRole', async () => {
+			const result = await communityRolesRepo.findById(-1);
+			t.ok(!result.ok);
+			t.is(result.type, 'noCommunityRoleFound');
+		});
+	});
+
+	test('findByCommunityAndName()', async () => {
+		test('finds one by name', async () => {
+			const result = await communityRolesRepo.findByCommunityAndName(
+				testCommunity,
+				testCommunityRole.name,
+			);
+			t.ok(result.ok);
+			t.equal(result.value, testCommunityRole);
+		});
+		test('finds one by name with a different case', async () => {
+			const result = await communityRolesRepo.findByCommunityAndName(
+				testCommunity,
+				testNameUppercase,
+			);
+			t.ok(result.ok);
+			t.equal(result.value, testCommunityRole);
+		});
+		test('fails to find a nonexistent communityRole', async () => {
+			const result = await communityRolesRepo.findByCommunityAndName(testCommunity, randomName());
+			t.ok(!result.ok);
+			t.is(result.type, 'noCommunityRoleFound');
+		});
+		test('fails with an invalid name', async () => {
+			const result = await communityRolesRepo.findByCommunityAndName(testCommunity, '1');
+			t.ok(!result.ok);
+			t.is(result.type, 'invalidName');
+		});
+	});
+
+	test('findByCommunity()', async () => {
+		test('finds all by community', async () => {
+			const result = await communityRolesRepo.findByCommunity(testCommunity);
+			t.ok(result.ok);
+			t.ok(result.value.length > 1);
+			for (const communityRole of result.value) {
+				t.is(communityRole.community, testCommunity);
+			}
+			// query the second test community's communityRoles
+			const result2 = await communityRolesRepo.findByCommunity(testCommunity2);
+			t.ok(result2.ok);
+			t.ok(result2.value.length > 1);
+			for (const communityRole of result2.value) {
+				t.is(communityRole.community, testCommunity2);
+			}
+		});
+		test('fails to find with an invalid community', async () => {
+			const result = await communityRolesRepo.findByCommunity(-1);
+			t.ok(result.ok);
+			t.is(result.value.length, 0);
+		});
+		test('fails with a null community', async () => {
+			const result = await communityRolesRepo.findByCommunity(null as any);
+			t.ok(result.ok);
+			t.is(result.value.length, 0);
+		});
+		test('errors without an community', async () => {
+			await t.rejects(communityRolesRepo.findByCommunity(undefined as any));
+		});
+	});
+});

--- a/src/communities/CommunityRolesRepo.ts
+++ b/src/communities/CommunityRolesRepo.ts
@@ -1,0 +1,98 @@
+import {Repo} from '../db/Repo.js';
+import {CommunityRoleModel, CommunityRoleModelId} from './CommunityRoleModel.js';
+import {CommunityModelId} from './CommunityModel.js';
+
+// TODO see notes in ../communities/CommunitiesRepo.ts
+const normalizeName = (name: string) => name.toLowerCase();
+const isName = (str: string): boolean => {
+	return typeof str === 'string' && str.length > 1;
+};
+
+export class CommunityRolesRepo extends Repo<CommunityRoleModel> {
+	name = 'communityRoles';
+
+	async create(
+		partialModel: Pick<CommunityRoleModel, 'community' | 'name'>,
+	): Promise<
+		Result<
+			{value: CommunityRoleModel},
+			{type: 'invalidName'; reason: string} | {type: 'duplicate'; reason: string}
+		>
+	> {
+		const {community} = partialModel; // TODO does this need validation? just let the db throw?
+
+		// TODO formalized normalization + validation
+		const name = normalizeName(partialModel.name); // TODO see name discussion in ./CommunitiesRepo.ts
+		if (!isName(name)) {
+			return {ok: false, type: 'invalidName', reason: `Invalid name '${name}'.`};
+		}
+
+		// Disallow duplicates with the same name within a community.
+		// Does not rely on database to throw a uniqueness error.
+		// TODO should it? see other repo `create` functions too
+		const existingCommunityRole = await this.findByCommunityAndName(community, name);
+		if (existingCommunityRole.ok) {
+			// TODO seems there could be a hole in our logic here and in similar checks in other repos.
+			// If the database query fails for reasons that don't throw an error,
+			// we could falsely think that there's no communityRole with this name.
+			// (currently this won't happen, but it could with future changes)
+			// The database primary key should block duplicates in this case, (I think?)
+			// but what about other cases? (do any repos hae this possible issue?)
+			return {
+				ok: false,
+				type: 'duplicate',
+				reason: `CommunityRole already exists with community ${community} and name '${name}'.`,
+			};
+		}
+
+		const value = (await this.query().insert({name, community}).returning('*'))[0];
+		return {ok: true, value};
+	}
+
+	async findById(
+		id: CommunityRoleModelId,
+	): Promise<Result<{value: CommunityRoleModel}, {type: 'noCommunityRoleFound'; reason: string}>> {
+		const value = await this.query().where('id', id).first();
+		return value
+			? {ok: true, value}
+			: {
+					ok: false,
+					type: 'noCommunityRoleFound',
+					reason: `Cannot find communityRole with id ${id}.`,
+			  };
+	}
+
+	// TODO do we want this method? probably?
+	async findByCommunityAndName(
+		community: CommunityModelId,
+		name: string,
+	): Promise<
+		Result<
+			{value: CommunityRoleModel},
+			{type: 'invalidName'; reason: string} | {type: 'noCommunityRoleFound'; reason: string}
+		>
+	> {
+		name = normalizeName(name); // TODO see name discussion in ./CommunitiesRepo.ts
+		if (!isName(name)) {
+			// TODO formalize validation
+			return {ok: false, type: 'invalidName', reason: `Invalid name '${name}'.`};
+		}
+		const value = await this.query().where({community, name}).first();
+		return value
+			? {ok: true, value}
+			: {
+					ok: false,
+					type: 'noCommunityRoleFound',
+					reason: `Cannot find communityRole with community ${community} and name '${name}'.`,
+			  };
+	}
+
+	async findByCommunity(
+		community: CommunityModelId,
+	): Promise<Result<{value: CommunityRoleModel[]}>> {
+		// TODO the `Result` isn't used here - should we change the code to return `CommunityRoleModel[]`?
+		// or is it likely we'll want to wrap certain errors in the future with a result failure?
+		const value = await this.query().where('community', community);
+		return value ? {ok: true, value} : {ok: false};
+	}
+}

--- a/src/db/Db.ts
+++ b/src/db/Db.ts
@@ -5,6 +5,8 @@ import {AccountsRepo} from '../accounts/AccountsRepo.js';
 import {LoginsRepo} from '../accounts/LoginsRepo.js';
 import {PersonasRepo} from '../personas/PersonasRepo.js';
 import {CommunitiesRepo} from '../communities/CommunitiesRepo.js';
+import {CommunityRolesRepo} from '../communities/CommunityRolesRepo.js';
+import {PersonaCommunityRolesRepo} from '../personas/PersonaCommunityRolesRepo.js';
 
 /*
 
@@ -31,6 +33,8 @@ export class Db {
 			logins: new LoginsRepo(knex),
 			personas: new PersonasRepo(knex),
 			communities: new CommunitiesRepo(knex),
+			communityRoles: new CommunityRolesRepo(knex),
+			personaCommunityRoles: new PersonaCommunityRolesRepo(knex),
 		};
 	}
 
@@ -44,4 +48,6 @@ interface DbRepos {
 	readonly logins: LoginsRepo;
 	readonly personas: PersonasRepo;
 	readonly communities: CommunitiesRepo;
+	readonly communityRoles: CommunityRolesRepo;
+	readonly personaCommunityRoles: PersonaCommunityRolesRepo;
 }

--- a/src/db/migrations/20200403163837_init.ts
+++ b/src/db/migrations/20200403163837_init.ts
@@ -39,7 +39,6 @@ export const up = async (knex: KnexInstance) => {
 		t.integer('community').unsigned().notNullable();
 		t.foreign('community').references('id').inTable('communities');
 		t.text('name').notNullable(); // TODO does this need an index? or does the primary key handle this?
-		// t.primary(['community', 'name']); // TODO these don't work because of the foreign keys I think? is this not correct to try?
 		t.json('permissions'); // TODO?
 	});
 
@@ -49,6 +48,5 @@ export const up = async (knex: KnexInstance) => {
 		t.foreign('persona').references('id').inTable('personas');
 		t.integer('communityRole').unsigned().notNullable();
 		t.foreign('communityRole').references('id').inTable('communityRoles');
-		// t.primary(['persona', 'communityRole']); // TODO these don't work because of the foreign keys I think? is this not correct to try?
 	});
 };

--- a/src/db/migrations/20200403163837_init.ts
+++ b/src/db/migrations/20200403163837_init.ts
@@ -33,4 +33,22 @@ export const up = async (knex: KnexInstance) => {
 		t.text('name').index().notNullable().unique();
 		// t.text('icon').notNullable(); // see above in personas
 	});
+
+	await knex.schema.createTable('communityRoles', (t) => {
+		t.increments();
+		t.integer('community').unsigned().notNullable();
+		t.foreign('community').references('id').inTable('communities');
+		t.text('name').notNullable(); // TODO does this need an index? or does the primary key handle this?
+		// t.primary(['community', 'name']); // TODO these don't work because of the foreign keys I think? is this not correct to try?
+		t.json('permissions'); // TODO?
+	});
+
+	await knex.schema.createTable('personaCommunityRoles', (t) => {
+		t.increments();
+		t.integer('persona').unsigned().notNullable();
+		t.foreign('persona').references('id').inTable('personas');
+		t.integer('communityRole').unsigned().notNullable();
+		t.foreign('communityRole').references('id').inTable('communityRoles');
+		// t.primary(['persona', 'communityRole']); // TODO these don't work because of the foreign keys I think? is this not correct to try?
+	});
 };

--- a/src/personas/PersonaCommunityRoleModel.ts
+++ b/src/personas/PersonaCommunityRoleModel.ts
@@ -1,0 +1,11 @@
+import {ModelId} from '../db/Model.js';
+import {PersonaModelId} from './PersonaModel.js';
+import {CommunityRoleModelId} from '../communities/CommunityRoleModel.js';
+
+export type PersonaCommunityRoleModelId = ModelId<PersonaCommunityRoleModel>;
+
+export interface PersonaCommunityRoleModel {
+	id: PersonaCommunityRoleModelId;
+	persona: PersonaModelId;
+	communityRole: CommunityRoleModelId;
+}

--- a/src/personas/PersonaCommunityRolesRepo.test.ts
+++ b/src/personas/PersonaCommunityRolesRepo.test.ts
@@ -1,0 +1,81 @@
+import {test, t} from '@feltcoop/gro';
+
+import {PersonaCommunityRolesRepo} from './PersonaCommunityRolesRepo.js';
+import {CommunityRolesRepo} from '../communities/CommunityRolesRepo.js';
+import {getKnex} from '../test.task.js';
+import {PersonaCommunityRoleModel} from './PersonaCommunityRoleModel.js';
+
+test('PersonaCommunityRolesRepo', async () => {
+	const testPersona = 1;
+	// TODO improve all of this setup code
+	const testCommunityRolesRepo = new CommunityRolesRepo(getKnex());
+	const testCommunityRoleResult = await testCommunityRolesRepo.create({
+		community: 1,
+		name: `community_role_name_${Math.random()}`,
+	});
+	if (!testCommunityRoleResult.ok) throw Error();
+	const testCommunityRole = testCommunityRoleResult.value.id;
+	const personaCommunityRolesRepo = new PersonaCommunityRolesRepo(getKnex());
+	let testPersonaCommunityRole: PersonaCommunityRoleModel;
+
+	test('create()', async () => {
+		test('creates a personaCommunityRole', async () => {
+			const result = await personaCommunityRolesRepo.create({
+				persona: testPersona,
+				communityRole: testCommunityRole,
+			});
+			t.ok(result.ok);
+			t.is(result.value.persona, testPersona);
+			t.is(result.value.communityRole, testCommunityRole);
+			testPersonaCommunityRole = result.value;
+		});
+
+		// TODO test duplicate
+
+		test('errors with an invalid persona', async () => {
+			await t.rejects(
+				personaCommunityRolesRepo.create({persona: -1, communityRole: testCommunityRole}),
+			);
+		});
+		test('errors with an invalid communityRole', async () => {
+			await t.rejects(personaCommunityRolesRepo.create({persona: testPersona, communityRole: -1}));
+		});
+	});
+
+	test('findById()', async () => {
+		test('finds one by id', async () => {
+			const result = await personaCommunityRolesRepo.findById(testPersonaCommunityRole.id);
+			t.ok(result.ok);
+			t.equal(result.value, testPersonaCommunityRole);
+		});
+		test('fails to find a nonexistent persona', async () => {
+			const result = await personaCommunityRolesRepo.findById(-1);
+			t.ok(!result.ok);
+			t.is(result.type, 'noPersonaCommunityRoleFound');
+		});
+	});
+
+	test('findByPersonaAndCommunityRole()', async () => {
+		test('finds one by persona and communityRole', async () => {
+			const result = await personaCommunityRolesRepo.findByPersonaAndCommunityRole(
+				testPersona,
+				testCommunityRole,
+			);
+			t.ok(result.ok);
+			t.equal(result.value, testPersonaCommunityRole);
+		});
+		test('fails to find a nonexistent persona', async () => {
+			const result = await personaCommunityRolesRepo.findByPersonaAndCommunityRole(
+				-1,
+				testCommunityRole,
+			);
+			t.ok(!result.ok);
+		});
+		test('fails with an invalid name', async () => {
+			const result = await personaCommunityRolesRepo.findByPersonaAndCommunityRole(testPersona, -1);
+			t.ok(!result.ok);
+		});
+	});
+
+	// TODO need other helper find methods to query data for personas/communities
+});

--- a/src/personas/PersonaCommunityRolesRepo.ts
+++ b/src/personas/PersonaCommunityRolesRepo.ts
@@ -1,0 +1,71 @@
+import {Repo} from '../db/Repo.js';
+import {
+	PersonaCommunityRoleModel,
+	PersonaCommunityRoleModelId,
+} from './PersonaCommunityRoleModel.js';
+import {CommunityRoleModelId} from '../communities/CommunityRoleModel.js';
+import {PersonaModelId} from './PersonaModel.js';
+
+export class PersonaCommunityRolesRepo extends Repo<PersonaCommunityRoleModel> {
+	name = 'personaCommunityRoles';
+
+	async create(
+		partialModel: Pick<PersonaCommunityRoleModel, 'persona' | 'communityRole'>,
+	): Promise<
+		Result<
+			{value: PersonaCommunityRoleModel},
+			{type: 'invalidName'; reason: string} | {type: 'duplicate'; reason: string}
+		>
+	> {
+		const {persona, communityRole} = partialModel; // TODO does this need validation? just let the db throw?
+
+		// TODO should it rely on the db primary key uniqueness? (test that it can)
+		// How can we robustly detect that error case and return a good error result?
+
+		// Disallow duplicates. Does not rely on database to throw a uniqueness error.
+		const existingPersonaCommunityRole = await this.findByPersonaAndCommunityRole(
+			persona,
+			communityRole,
+		);
+		if (existingPersonaCommunityRole.ok) {
+			return {
+				ok: false,
+				type: 'duplicate',
+				reason: `PersonaCommunityRole already exists for persona ${persona} and communityRole ${communityRole}.`,
+			};
+		}
+
+		const value = (await this.query().insert({persona, communityRole}).returning('*'))[0];
+		return {ok: true, value};
+	}
+
+	async findById(
+		id: PersonaCommunityRoleModelId,
+	): Promise<
+		Result<
+			{value: PersonaCommunityRoleModel},
+			{type: 'noPersonaCommunityRoleFound'; reason: string}
+		>
+	> {
+		const value = await this.query().where('id', id).first();
+		return value
+			? {ok: true, value}
+			: {
+					ok: false,
+					type: 'noPersonaCommunityRoleFound',
+					reason: `Cannot find personaCommunityRole with id ${id}.`,
+			  };
+	}
+
+	// TODO what other methods do we need? findByPersona? findByCommunityRole?
+
+	async findByPersonaAndCommunityRole(
+		persona: PersonaModelId,
+		communityRole: CommunityRoleModelId,
+	): Promise<Result<{value: PersonaCommunityRoleModel}>> {
+		// TODO the `Result` isn't used here - should we change the code to return `PeronaCommunityRoleModel`?
+		// or is it likely we'll want to wrap certain errors in the future with a result failure?
+		const value = await this.query().where({persona, communityRole}).first();
+		return value ? {ok: true, value} : {ok: false};
+	}
+}


### PR DESCRIPTION
This is a very rough first draft that adds `communityRoles` and `personaCommunityRoles`. I'm only opening it in case you want to take a look and/or dive in - I probably won't get to it until after Thanksgiving.

Some notes:

- there's probably some nonsensical copy/paste
- the database fields aren't thought through
- the repo methods aren't thought through
- there's no integration yet with the actual behavior of the app, only initial scaffolding of the db/repos/tests (see `src/db/loadClientSession.ts` for one such point of interaction, where the roles need to be used to query the session's communities)