### PR TITLE
replace svelte-preprocess with svelte-preprocess-esbuild

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,27 +47,6 @@
 								"svelte-hmr": "^0.13.3"
 						}
 				},
-				"@types/node": {
-						"version": "14.14.37",
-						"resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.37.tgz",
-						"integrity": "sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw==",
-						"dev": true
-				},
-				"@types/pug": {
-						"version": "2.0.4",
-						"resolved": "https://registry.npmjs.org/@types/pug/-/pug-2.0.4.tgz",
-						"integrity": "sha1-h3L80EGOPNLMFxVV1zAHQVBR9LI=",
-						"dev": true
-				},
-				"@types/sass": {
-						"version": "1.16.0",
-						"resolved": "https://registry.npmjs.org/@types/sass/-/sass-1.16.0.tgz",
-						"integrity": "sha512-2XZovu4NwcqmtZtsBR5XYLw18T8cBCnU2USFHTnYLLHz9fkhnoEMoDsqShJIOFsFhn5aJHjweiUUdTrDGujegA==",
-						"dev": true,
-						"requires": {
-								"@types/node": "*"
-						}
-				},
 				"ansi-styles": {
 						"version": "4.3.0",
 						"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -123,12 +102,6 @@
 								"ms": "2.1.2"
 						}
 				},
-				"detect-indent": {
-						"version": "6.0.0",
-						"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.0.0.tgz",
-						"integrity": "sha512-oSyFlqaTHCItVRGK5RmrmjB+CmaMOW7IaNA/kdxqhoa6d17j/5ce9O9eWXmV/KEdRwqpQA+Vqe8a8Bsybu4YnA==",
-						"dev": true
-				},
 				"esbuild": {
 						"version": "0.9.7",
 						"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.9.7.tgz",
@@ -183,12 +156,6 @@
 						"requires": {
 								"has": "^1.0.3"
 						}
-				},
-				"min-indent": {
-						"version": "1.0.1",
-						"resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
-						"integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
-						"dev": true
 				},
 				"mri": {
 						"version": "1.1.6",
@@ -297,15 +264,6 @@
 						"integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
 						"dev": true
 				},
-				"strip-indent": {
-						"version": "3.0.0",
-						"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
-						"integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
-						"dev": true,
-						"requires": {
-								"min-indent": "^1.0.0"
-						}
-				},
 				"supports-color": {
 						"version": "7.2.0",
 						"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -327,17 +285,11 @@
 						"integrity": "sha512-gagW62pLQ2lULmvNA3pIZu9pBCYOaGu3rQikUOv6Nokz5VxUgT9/mQLfMxj9phDEKHCg/lgr3i6PkqZDbO9P2Q==",
 						"dev": true
 				},
-				"svelte-preprocess": {
-						"version": "4.7.0",
-						"resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-4.7.0.tgz",
-						"integrity": "sha512-iNrY4YGqi0LD2e6oT9YbdSzOKntxk8gmzfqso1z/lUJOZh4o6fyIqkirmiZ8/dDJFqtIE1spVgDFWgkfhLEYlw==",
-						"dev": true,
-						"requires": {
-								"@types/pug": "^2.0.4",
-								"@types/sass": "^1.16.0",
-								"detect-indent": "^6.0.0",
-								"strip-indent": "^3.0.0"
-						}
+				"svelte-preprocess-esbuild": {
+						"version": "2.0.0",
+						"resolved": "https://registry.npmjs.org/svelte-preprocess-esbuild/-/svelte-preprocess-esbuild-2.0.0.tgz",
+						"integrity": "sha512-kGJ14aXcQEcyteoIijDDPvMDIq/CpkMbkW/wAFISD//KGXu7Y5fi4T/6/whKgHZFY1vw52D1SrTwN34uvTjdjw==",
+						"dev": true
 				},
 				"tslib": {
 						"version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "prettier": "~2.2.1",
     "prettier-plugin-svelte": "^2.2.0",
     "svelte": "^3.29.0",
-    "svelte-preprocess": "^4.0.0",
+    "svelte-preprocess-esbuild": "^2.0.0",
     "tslib": "^2.1.0",
     "typescript": "^4.0.0",
     "vite": "^2.1.0"

--- a/svelte.config.cjs
+++ b/svelte.config.cjs
@@ -1,16 +1,11 @@
-const sveltePreprocess = require('svelte-preprocess');
+const {typescript} = require('svelte-preprocess-esbuild');
 const node = require('@sveltejs/adapter-node');
 const pkg = require('./package.json');
 
 /** @type {import('@sveltejs/kit').Config} */
 module.exports = {
-	// Consult https://github.com/sveltejs/svelte-preprocess
-	// for more information about preprocessors
-	preprocess: sveltePreprocess(),
+	preprocess: typescript(),
 	kit: {
-		// By default, `npm run build` will create a standard Node app.
-		// You can create optimized builds for different platforms by
-		// specifying a different adapter
 		adapter: node(),
 
 		// hydrate the <div id="svelte"> element in src/app.html
@@ -18,8 +13,8 @@ module.exports = {
 
 		vite: {
 			ssr: {
-				noExternal: Object.keys(pkg.dependencies || {})
-			}
-		}
-	}
+				noExternal: Object.keys(pkg.dependencies || {}),
+			},
+		},
+	},
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,29 +1,21 @@
 {
-	"compilerOptions": {
-		"moduleResolution": "node",
-		"target": "es2018",
-		/**
-			svelte-preprocess cannot figure out whether you have a value or a type, so tell TypeScript
-			to enforce using \`import type\` instead of \`import\` for Types.
-			*/
-		"importsNotUsedAsValues": "error",
-		"isolatedModules": true,
-		/**
-			To have warnings/errors of the Svelte compiler at the correct position,
-			enable source maps by default.
-			*/
-		"sourceMap": true,
-		"esModuleInterop": true,
-		"skipLibCheck": true,
-		"forceConsistentCasingInFileNames": true,
-		"baseUrl": ".",
-		"allowJs": true,
-		"checkJs": true,
-		"paths": {
-			"$app/*": [".svelte/dev/runtime/app/*", ".svelte/build/runtime/app/*"],
-			"$service-worker": [".svelte/build/runtime/service-worker"],
-			"$lib/*": ["src/lib/*"]
-		}
-	},
-	"include": ["src/**/*.d.ts", "src/**/*.js", "src/**/*.ts", "src/**/*.svelte"]
+  "compilerOptions": {
+    "moduleResolution": "node",
+    "target": "es2018",
+    "importsNotUsedAsValues": "error",
+    "isolatedModules": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": ".",
+    "allowJs": true,
+    "checkJs": true,
+    "paths": {
+      "$app/*": [".svelte/dev/runtime/app/*", ".svelte/build/runtime/app/*"],
+      "$service-worker": [".svelte/build/runtime/service-worker"],
+      "$lib/*": ["src/lib/*"]
+    }
+  },
+  "include": ["src/**/*.d.ts", "src/**/*.js", "src/**/*.ts", "src/**/*.svelte"]
 }


### PR DESCRIPTION
This replaces the builtin Svelte preprocessor with [svelte-preprocess-esbuild](https://github.com/lukeed/svelte-preprocess-esbuild). It's faster, does everything we need, drops some dependencies, and we already had `esbuild` as a transitive dependency through Vite.

The  preprocessor is used to transform the TypeScript in our `<script lang="ts">` tags from TS to JS with sourcemaps. From there, the Svelte compiler takes over to do its thing. So it only impacts a portion of the overall compilation time: in my rough tests I saw between a 25-50% speedup.