### PR TITLE
fix import and improve icons list style

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,9 +21,9 @@
 						"dev": true
 				},
 				"@sveltejs/kit": {
-						"version": "1.0.0-next.67",
-						"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.67.tgz",
-						"integrity": "sha512-c/UN8PWRI2eu0IoJywZ9D+adtDyGM0r9fN/1WwQnzyYUk/fLzASaxSZa1TLtgOzzY2MV8u4WzbgGLgG1JHTy0w==",
+						"version": "1.0.0-next.71",
+						"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.71.tgz",
+						"integrity": "sha512-9oZEKtuFpmJanL0u7oJPWIoC4kWMtNSuN1SN7xKo+g54xI6JcsoH2J15OkTU89Hsd9Ctp4/OTh9j6/vgq9J7gw==",
 						"dev": true,
 						"requires": {
 								"@sveltejs/vite-plugin-svelte": "^1.0.0-next.5",

--- a/src/app.css
+++ b/src/app.css
@@ -2,3 +2,7 @@
 	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
 		'Open Sans', 'Helvetica Neue', sans-serif;
 }
+
+li {
+	list-style: none;
+}

--- a/src/lib/Icons.svelte
+++ b/src/lib/Icons.svelte
@@ -1,10 +1,19 @@
-<script>
-    export let icons;            
+<script lang="ts">
+	export let icons: {name: string; icon: string}[];
+	$: titleIcon = icons.find((icon) => icon.name === 'feltIcon');
 </script>
 
-<h1>{icons.feltIcon}Icons{icons.feltIcon}</h1>
-<ul>    
-    {#each Object.entries(icons) as icon}
-		<li>{icon}</li>	
-    {/each}
+<h1>{titleIcon.icon}Icons{titleIcon.icon}</h1>
+<ul>
+	{#each icons as {name, icon} (name)}
+		<li>{icon} {name}</li>
+	{/each}
 </ul>
+
+<style>
+	ul {
+		display: grid;
+		grid: auto-flow / repeat(auto-fill, 200px);
+		text-align: left;
+	}
+</style>

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -1,9 +1,13 @@
-<script lang="ts">	
+<script lang="ts">
 	import Icons from '$lib/Icons.svelte';
-	import * as icons from '$lib/icons.ts';
+	import * as iconsByName from '$lib/icons';
+
+	$: icons = Object.entries(iconsByName)
+		.map(([name, icon]) => ({name, icon}))
+		.sort((a, b) => a.name.localeCompare(b.name));
 </script>
 
-<main>					    
+<main>
 	<Icons {icons} />
 
 	<p>Visit <a href="https://svelte.dev">svelte.dev</a> to learn how to build Svelte apps.</p>
@@ -16,16 +20,6 @@
 		margin: 0 auto;
 	}
 
-	h1 {
-		color: #ff3e00;
-		text-transform: uppercase;
-		font-size: 4rem;
-		font-weight: 100;
-		line-height: 1.1;
-		margin: 4rem auto;
-		max-width: 14rem;
-	}
-
 	p {
 		max-width: 14rem;
 		margin: 2rem auto;
@@ -33,10 +27,6 @@
 	}
 
 	@media (min-width: 480px) {
-		h1 {
-			max-width: none;
-		}
-
 		p {
 			max-width: none;
 		}


### PR DESCRIPTION
This PR was motivated by changing this line:

> import * as icons from '$lib/icons.ts';

to this:

> import * as icons from '$lib/icons';

It's a quirk of TypeScript that we never import modules using the suffix `.ts`. The compiler actually disallows it and throws an error. Vite/SvelteKit allow it, and make it work, but it's making Vscode error. Further, the actual correct syntax for ES modules is not currently supported by Vite/SvelteKit, but I can only imagine they will fix it:

> import * as icons from '$lib/icons.js';

Some other changes:

- add `list-style: none` to the global `app.css`. This is the first global style rule added. The idea is that `li` gets used commonly, but you only want bullet point styling in "normal markup". We'll create a component or class for normal markup, which will add back the bullet points and other text-appropriate styling.
- change `<script>` to `<script lang="ts">`. You'll want the Svelte extension installed in Vscode if you don't have it.
- sort the icons - previously, the server-side sort was different than the client-side sort due to module packaging in Vite, making it re-sort when the page loaded, so now we sort ourselves and get a stable order
- use CSS grid to give a basic responsive number of columns to the layout
- remove some dead styles

![image](https://user-images.githubusercontent.com/2608646/113729987-559fa800-96ac-11eb-89dc-cf553a4f7f71.png)
