### PR TITLE
implement static adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ npm run dev
 
 ```bash
 npm run build
-node build
+npm start
 ```
 
 # :turtle:<sub>:turtle:</sub><sub><sub>:turtle:</sub></sub>

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,10 +14,10 @@
 								"picomatch": "^2.2.2"
 						}
 				},
-				"@sveltejs/adapter-node": {
-						"version": "1.0.0-next.12",
-						"resolved": "https://registry.npmjs.org/@sveltejs/adapter-node/-/adapter-node-1.0.0-next.12.tgz",
-						"integrity": "sha512-DGP3dT5ijsTV0zmLDmZP8wI4RjZlifGGzA0y4HLoWNEKhZJLDjFDJnNcA+O5S9QBxQOVaYUlAY2z19r+skBVjA==",
+				"@sveltejs/adapter-static": {
+						"version": "1.0.0-next.4",
+						"resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-1.0.0-next.4.tgz",
+						"integrity": "sha512-Atri/5jyiVmAklqDKb/5czmLkHos6LQOag61k/C6qWozMb8UopvL3bTm62hFQXGKvGnuSRq2xIueDOKWHM/7rA==",
 						"dev": true
 				},
 				"@sveltejs/kit": {

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@sveltejs/adapter-node": "next",
-    "@sveltejs/kit": "next",
+    "@sveltejs/adapter-static": "^1.0.0-next.4",
+    "@sveltejs/kit": "^1.0.0-next.71",
     "prettier": "~2.2.1",
     "prettier-plugin-svelte": "^2.2.0",
     "svelte": "^3.29.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {},
   "devDependencies": {
     "@sveltejs/adapter-static": "^1.0.0-next.4",
-    "@sveltejs/kit": "^1.0.0-next.71",
+    "@sveltejs/kit": "next",
     "prettier": "~2.2.1",
     "prettier-plugin-svelte": "^2.2.0",
     "svelte": "^3.29.0",

--- a/svelte.config.cjs
+++ b/svelte.config.cjs
@@ -1,12 +1,14 @@
 const {typescript} = require('svelte-preprocess-esbuild');
-const node = require('@sveltejs/adapter-node');
+const staticAdapter = require('@sveltejs/adapter-static');
 const pkg = require('./package.json');
+
+// console.log('staticAdapter', staticAdapter());
 
 /** @type {import('@sveltejs/kit').Config} */
 module.exports = {
 	preprocess: typescript(),
 	kit: {
-		adapter: node(),
+		adapter: staticAdapter(),
 
 		// hydrate the <div id="svelte"> element in src/app.html
 		target: '#svelte',

--- a/svelte.config.cjs
+++ b/svelte.config.cjs
@@ -2,8 +2,6 @@ const {typescript} = require('svelte-preprocess-esbuild');
 const staticAdapter = require('@sveltejs/adapter-static');
 const pkg = require('./package.json');
 
-// console.log('staticAdapter', staticAdapter());
-
 /** @type {import('@sveltejs/kit').Config} */
 module.exports = {
 	preprocess: typescript(),


### PR DESCRIPTION
This implements `@sveltejs/adapter-static` and removes `@sveltejs/adapter-node`.

We now need to run `npm start` to run the `build/` output from `npm run build`. The readme now reflects this.

`gro start` should work like `npm start`, but it currently fails because it doesn't know how to detect a SvelteKit project. I'm going to work on that in the next week or so.