### PR TITLE
deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,10 @@ node_modules
 /.svelte
 /build
 /functions
+
+/.gro
+/dist
+*.ignore
+*.ignore.*
+ignore/
+*.pem

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
 		"requires": true,
 		"dependencies": {
 				"@feltcoop/gro": {
-						"version": "0.16.0",
-						"resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.16.0.tgz",
-						"integrity": "sha512-LhUJn//zK8kOOVaI+Obo7NFeNjl9lkXkk/8ieK+NLC5kIoeSEyuDndmf3gzPmCeh7YeF0iyr9+1HFaMaov+i5A==",
+						"version": "0.17.0",
+						"resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.17.0.tgz",
+						"integrity": "sha512-u1EfKijKj/pBhCqlQAz+FW1MR+hUjiWHXXsrW7vl+hrOKCkE2om9jXVzlbZqum/oWkCnYgmAJAxi2c+ys0XYIw==",
 						"dev": true,
 						"requires": {
 								"@lukeed/uuid": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,222 @@
 		"lockfileVersion": 1,
 		"requires": true,
 		"dependencies": {
+				"@feltcoop/gro": {
+						"version": "0.16.0",
+						"resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.16.0.tgz",
+						"integrity": "sha512-LhUJn//zK8kOOVaI+Obo7NFeNjl9lkXkk/8ieK+NLC5kIoeSEyuDndmf3gzPmCeh7YeF0iyr9+1HFaMaov+i5A==",
+						"dev": true,
+						"requires": {
+								"@lukeed/uuid": "^2.0.0",
+								"@rollup/plugin-commonjs": "^18.0.0",
+								"@rollup/plugin-node-resolve": "^11.2.1",
+								"@rollup/pluginutils": "^4.1.0",
+								"@types/fs-extra": "^9.0.9",
+								"@types/node": "^14.14.37",
+								"@types/prettier": "^2.2.3",
+								"cheap-watch": "^1.0.3",
+								"dequal": "^2.0.2",
+								"es-module-lexer": "^0.4.1",
+								"esbuild": "^0.9.3",
+								"esinstall": "1.0.5",
+								"fs-extra": "^9.1.0",
+								"kleur": "^4.1.4",
+								"locate-character": "^2.0.5",
+								"mri": "^1.1.6",
+								"path-browserify": "^1.0.1",
+								"prettier": "^2.2.1",
+								"prettier-plugin-svelte": "^2.2.0",
+								"rollup": "^2.37.1",
+								"source-map-support": "^0.5.19",
+								"sourcemap-codec": "^1.4.8",
+								"strict-event-emitter-types": "^2.0.0",
+								"svelte": "^3.37.0",
+								"svelte-preprocess-esbuild": "^2.0.0",
+								"terser": "^5.6.1",
+								"tslib": "^2.1.0",
+								"typescript": "^4.2.3",
+								"uvu": "^0.5.1"
+						},
+						"dependencies": {
+								"svelte": {
+										"version": "3.37.0",
+										"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.37.0.tgz",
+										"integrity": "sha512-TRF30F4W4+d+Jr2KzUUL1j8Mrpns/WM/WacxYlo5MMb2E5Qy2Pk1Guj6GylxsW9OnKQl1tnF8q3hG/hQ3h6VUA==",
+										"dev": true
+								}
+						}
+				},
+				"@lukeed/csprng": {
+						"version": "1.0.0",
+						"resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.0.0.tgz",
+						"integrity": "sha512-ruuGHsnabmObBdeMg3vKdGRmh06Oog3eFpf/Tk6X0kDSJDpJTDCj2dqdp1+0VjzIUgHlFF9GBm7uFqfYhhdX9g==",
+						"dev": true
+				},
+				"@lukeed/uuid": {
+						"version": "2.0.0",
+						"resolved": "https://registry.npmjs.org/@lukeed/uuid/-/uuid-2.0.0.tgz",
+						"integrity": "sha512-dUz8OmYvlY5A9wXaroHIMSPASpSYRLCqbPvxGSyHguhtTQIy24lC+EGxQlwv71AhRCO55WOtgwhzQLpw27JaJQ==",
+						"dev": true,
+						"requires": {
+								"@lukeed/csprng": "^1.0.0"
+						}
+				},
+				"@rollup/plugin-commonjs": {
+						"version": "18.0.0",
+						"resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-18.0.0.tgz",
+						"integrity": "sha512-fj92shhg8luw7XbA0HowAqz90oo7qtLGwqTKbyZ8pmOyH8ui5e+u0wPEgeHLH3djcVma6gUCUrjY6w5R2o1u6g==",
+						"dev": true,
+						"requires": {
+								"@rollup/pluginutils": "^3.1.0",
+								"commondir": "^1.0.1",
+								"estree-walker": "^2.0.1",
+								"glob": "^7.1.6",
+								"is-reference": "^1.2.1",
+								"magic-string": "^0.25.7",
+								"resolve": "^1.17.0"
+						},
+						"dependencies": {
+								"@rollup/pluginutils": {
+										"version": "3.1.0",
+										"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+										"integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+										"dev": true,
+										"requires": {
+												"@types/estree": "0.0.39",
+												"estree-walker": "^1.0.1",
+												"picomatch": "^2.2.2"
+										},
+										"dependencies": {
+												"estree-walker": {
+														"version": "1.0.1",
+														"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+														"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+														"dev": true
+												}
+										}
+								}
+						}
+				},
+				"@rollup/plugin-inject": {
+						"version": "4.0.2",
+						"resolved": "https://registry.npmjs.org/@rollup/plugin-inject/-/plugin-inject-4.0.2.tgz",
+						"integrity": "sha512-TSLMA8waJ7Dmgmoc8JfPnwUwVZgLjjIAM6MqeIFqPO2ODK36JqE0Cf2F54UTgCUuW8da93Mvoj75a6KAVWgylw==",
+						"dev": true,
+						"requires": {
+								"@rollup/pluginutils": "^3.0.4",
+								"estree-walker": "^1.0.1",
+								"magic-string": "^0.25.5"
+						},
+						"dependencies": {
+								"@rollup/pluginutils": {
+										"version": "3.1.0",
+										"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+										"integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+										"dev": true,
+										"requires": {
+												"@types/estree": "0.0.39",
+												"estree-walker": "^1.0.1",
+												"picomatch": "^2.2.2"
+										}
+								},
+								"estree-walker": {
+										"version": "1.0.1",
+										"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+										"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+										"dev": true
+								}
+						}
+				},
+				"@rollup/plugin-json": {
+						"version": "4.1.0",
+						"resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-4.1.0.tgz",
+						"integrity": "sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==",
+						"dev": true,
+						"requires": {
+								"@rollup/pluginutils": "^3.0.8"
+						},
+						"dependencies": {
+								"@rollup/pluginutils": {
+										"version": "3.1.0",
+										"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+										"integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+										"dev": true,
+										"requires": {
+												"@types/estree": "0.0.39",
+												"estree-walker": "^1.0.1",
+												"picomatch": "^2.2.2"
+										}
+								},
+								"estree-walker": {
+										"version": "1.0.1",
+										"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+										"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+										"dev": true
+								}
+						}
+				},
+				"@rollup/plugin-node-resolve": {
+						"version": "11.2.1",
+						"resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-11.2.1.tgz",
+						"integrity": "sha512-yc2n43jcqVyGE2sqV5/YCmocy9ArjVAP/BeXyTtADTBBX6V0e5UMqwO8CdQ0kzjb6zu5P1qMzsScCMRvE9OlVg==",
+						"dev": true,
+						"requires": {
+								"@rollup/pluginutils": "^3.1.0",
+								"@types/resolve": "1.17.1",
+								"builtin-modules": "^3.1.0",
+								"deepmerge": "^4.2.2",
+								"is-module": "^1.0.0",
+								"resolve": "^1.19.0"
+						},
+						"dependencies": {
+								"@rollup/pluginutils": {
+										"version": "3.1.0",
+										"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+										"integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+										"dev": true,
+										"requires": {
+												"@types/estree": "0.0.39",
+												"estree-walker": "^1.0.1",
+												"picomatch": "^2.2.2"
+										}
+								},
+								"estree-walker": {
+										"version": "1.0.1",
+										"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+										"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+										"dev": true
+								}
+						}
+				},
+				"@rollup/plugin-replace": {
+						"version": "2.4.2",
+						"resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-2.4.2.tgz",
+						"integrity": "sha512-IGcu+cydlUMZ5En85jxHH4qj2hta/11BHq95iHEyb2sbgiN0eCdzvUcHw5gt9pBL5lTi4JDYJ1acCoMGpTvEZg==",
+						"dev": true,
+						"requires": {
+								"@rollup/pluginutils": "^3.1.0",
+								"magic-string": "^0.25.7"
+						},
+						"dependencies": {
+								"@rollup/pluginutils": {
+										"version": "3.1.0",
+										"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+										"integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+										"dev": true,
+										"requires": {
+												"@types/estree": "0.0.39",
+												"estree-walker": "^1.0.1",
+												"picomatch": "^2.2.2"
+										}
+								},
+								"estree-walker": {
+										"version": "1.0.1",
+										"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+										"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+										"dev": true
+								}
+						}
+				},
 				"@rollup/pluginutils": {
 						"version": "4.1.0",
 						"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.0.tgz",
@@ -47,6 +263,42 @@
 								"svelte-hmr": "^0.13.3"
 						}
 				},
+				"@types/estree": {
+						"version": "0.0.39",
+						"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+						"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+						"dev": true
+				},
+				"@types/fs-extra": {
+						"version": "9.0.10",
+						"resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.10.tgz",
+						"integrity": "sha512-O9T2LLkRDiTlalOBdjEkcnT0MRdT2+wglCl7pJUJ3mkWkR8hX4K+5bg2raQNJcLv4V8zGuTXe7Ud3wSqkTyuyQ==",
+						"dev": true,
+						"requires": {
+								"@types/node": "*"
+						}
+				},
+				"@types/node": {
+						"version": "14.14.37",
+						"resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.37.tgz",
+						"integrity": "sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw==",
+						"dev": true
+				},
+				"@types/prettier": {
+						"version": "2.2.3",
+						"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.2.3.tgz",
+						"integrity": "sha512-PijRCG/K3s3w1We6ynUKdxEc5AcuuH3NBmMDP8uvKVp6X43UY7NQlTzczakXP3DJR0F4dfNQIGjU2cUeRYs2AA==",
+						"dev": true
+				},
+				"@types/resolve": {
+						"version": "1.17.1",
+						"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
+						"integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
+						"dev": true,
+						"requires": {
+								"@types/node": "*"
+						}
+				},
 				"ansi-styles": {
 						"version": "4.3.0",
 						"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -55,6 +307,56 @@
 						"requires": {
 								"color-convert": "^2.0.1"
 						}
+				},
+				"assert": {
+						"version": "1.5.0",
+						"resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
+						"integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
+						"dev": true,
+						"requires": {
+								"object-assign": "^4.1.1",
+								"util": "0.10.3"
+						}
+				},
+				"at-least-node": {
+						"version": "1.0.0",
+						"resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+						"integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+						"dev": true
+				},
+				"balanced-match": {
+						"version": "1.0.2",
+						"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+						"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+						"dev": true
+				},
+				"brace-expansion": {
+						"version": "1.1.11",
+						"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+						"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+						"dev": true,
+						"requires": {
+								"balanced-match": "^1.0.0",
+								"concat-map": "0.0.1"
+						}
+				},
+				"buffer-from": {
+						"version": "1.1.1",
+						"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+						"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+						"dev": true
+				},
+				"builtin-modules": {
+						"version": "3.2.0",
+						"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.2.0.tgz",
+						"integrity": "sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==",
+						"dev": true
+				},
+				"builtins": {
+						"version": "1.0.3",
+						"resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
+						"integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
+						"dev": true
 				},
 				"chalk": {
 						"version": "4.1.0",
@@ -70,6 +372,12 @@
 						"version": "1.0.3",
 						"resolved": "https://registry.npmjs.org/cheap-watch/-/cheap-watch-1.0.3.tgz",
 						"integrity": "sha512-xC5CruMhLzjPwJ5ecUxGu1uGmwJQykUhqd2QrCrYbwvsFYdRyviu6jG9+pccwDXJR/OpmOTOJ9yLFunVgQu9wg==",
+						"dev": true
+				},
+				"cjs-module-lexer": {
+						"version": "1.1.1",
+						"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.1.1.tgz",
+						"integrity": "sha512-7/a2+QJu5Bt1WYi4vk0NinXin/4pEUBlygSree2N5dSlhc/szO0+HwYKL3llv7myOVingwTgmEHH4WO6Q7Zv7w==",
 						"dev": true
 				},
 				"color-convert": {
@@ -93,6 +401,24 @@
 						"integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
 						"dev": true
 				},
+				"commander": {
+						"version": "2.20.3",
+						"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+						"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+						"dev": true
+				},
+				"commondir": {
+						"version": "1.0.1",
+						"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+						"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+						"dev": true
+				},
+				"concat-map": {
+						"version": "0.0.1",
+						"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+						"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+						"dev": true
+				},
 				"debug": {
 						"version": "4.3.2",
 						"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
@@ -102,16 +428,156 @@
 								"ms": "2.1.2"
 						}
 				},
+				"deepmerge": {
+						"version": "4.2.2",
+						"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+						"integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+						"dev": true
+				},
+				"dequal": {
+						"version": "2.0.2",
+						"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.2.tgz",
+						"integrity": "sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==",
+						"dev": true
+				},
+				"diff": {
+						"version": "5.0.0",
+						"resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+						"integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+						"dev": true
+				},
+				"es-module-lexer": {
+						"version": "0.4.1",
+						"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.4.1.tgz",
+						"integrity": "sha512-ooYciCUtfw6/d2w56UVeqHPcoCFAiJdz5XOkYpv/Txl1HMUozpXjz/2RIQgqwKdXNDPSF1W7mJCFse3G+HDyAA==",
+						"dev": true
+				},
 				"esbuild": {
 						"version": "0.9.7",
 						"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.9.7.tgz",
 						"integrity": "sha512-VtUf6aQ89VTmMLKrWHYG50uByMF4JQlVysb8dmg6cOgW8JnFCipmz7p+HNBl+RR3LLCuBxFGVauAe2wfnF9bLg==",
 						"dev": true
 				},
+				"esinstall": {
+						"version": "1.0.5",
+						"resolved": "https://registry.npmjs.org/esinstall/-/esinstall-1.0.5.tgz",
+						"integrity": "sha512-ID7w4RbCAGxp3wdZQMsxT9stImvqWO7YqO7MFyvEsoxCE1hzDb/IOlxFXDdOWH17nLq3+PS6fZ772/BYeMPY4Q==",
+						"dev": true,
+						"requires": {
+								"@rollup/plugin-commonjs": "^16.0.0",
+								"@rollup/plugin-inject": "^4.0.2",
+								"@rollup/plugin-json": "^4.0.0",
+								"@rollup/plugin-node-resolve": "^10.0.0",
+								"@rollup/plugin-replace": "^2.3.3",
+								"builtin-modules": "^3.2.0",
+								"cjs-module-lexer": "^1.0.0",
+								"es-module-lexer": "^0.3.24",
+								"is-valid-identifier": "^2.0.2",
+								"kleur": "^4.1.1",
+								"mkdirp": "^1.0.3",
+								"picomatch": "^2.2.2",
+								"rimraf": "^3.0.0",
+								"rollup": "2.37.1",
+								"rollup-plugin-polyfill-node": "^0.5.0",
+								"slash": "^3.0.0",
+								"validate-npm-package-name": "^3.0.0",
+								"vm2": "^3.9.2"
+						},
+						"dependencies": {
+								"@rollup/plugin-commonjs": {
+										"version": "16.0.0",
+										"resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-16.0.0.tgz",
+										"integrity": "sha512-LuNyypCP3msCGVQJ7ki8PqYdpjfEkE/xtFa5DqlF+7IBD0JsfMZ87C58heSwIMint58sAUZbt3ITqOmdQv/dXw==",
+										"dev": true,
+										"requires": {
+												"@rollup/pluginutils": "^3.1.0",
+												"commondir": "^1.0.1",
+												"estree-walker": "^2.0.1",
+												"glob": "^7.1.6",
+												"is-reference": "^1.2.1",
+												"magic-string": "^0.25.7",
+												"resolve": "^1.17.0"
+										}
+								},
+								"@rollup/plugin-node-resolve": {
+										"version": "10.0.0",
+										"resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-10.0.0.tgz",
+										"integrity": "sha512-sNijGta8fqzwA1VwUEtTvWCx2E7qC70NMsDh4ZG13byAXYigBNZMxALhKUSycBks5gupJdq0lFrKumFrRZ8H3A==",
+										"dev": true,
+										"requires": {
+												"@rollup/pluginutils": "^3.1.0",
+												"@types/resolve": "1.17.1",
+												"builtin-modules": "^3.1.0",
+												"deepmerge": "^4.2.2",
+												"is-module": "^1.0.0",
+												"resolve": "^1.17.0"
+										}
+								},
+								"@rollup/pluginutils": {
+										"version": "3.1.0",
+										"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+										"integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+										"dev": true,
+										"requires": {
+												"@types/estree": "0.0.39",
+												"estree-walker": "^1.0.1",
+												"picomatch": "^2.2.2"
+										},
+										"dependencies": {
+												"estree-walker": {
+														"version": "1.0.1",
+														"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+														"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+														"dev": true
+												}
+										}
+								},
+								"es-module-lexer": {
+										"version": "0.3.26",
+										"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.3.26.tgz",
+										"integrity": "sha512-Va0Q/xqtrss45hWzP8CZJwzGSZJjDM5/MJRE3IXXnUCcVLElR9BRaE9F62BopysASyc4nM3uwhSW7FFB9nlWAA==",
+										"dev": true
+								},
+								"fsevents": {
+										"version": "2.1.3",
+										"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+										"integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+										"dev": true,
+										"optional": true
+								},
+								"rollup": {
+										"version": "2.37.1",
+										"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.37.1.tgz",
+										"integrity": "sha512-V3ojEeyGeSdrMSuhP3diBb06P+qV4gKQeanbDv+Qh/BZbhdZ7kHV0xAt8Yjk4GFshq/WjO7R4c7DFM20AwTFVQ==",
+										"dev": true,
+										"requires": {
+												"fsevents": "~2.1.2"
+										}
+								}
+						}
+				},
 				"estree-walker": {
 						"version": "2.0.2",
 						"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
 						"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+						"dev": true
+				},
+				"fs-extra": {
+						"version": "9.1.0",
+						"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+						"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+						"dev": true,
+						"requires": {
+								"at-least-node": "^1.0.0",
+								"graceful-fs": "^4.2.0",
+								"jsonfile": "^6.0.1",
+								"universalify": "^2.0.0"
+						}
+				},
+				"fs.realpath": {
+						"version": "1.0.0",
+						"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+						"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 						"dev": true
 				},
 				"fsevents": {
@@ -125,6 +591,26 @@
 						"version": "1.1.1",
 						"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
 						"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+						"dev": true
+				},
+				"glob": {
+						"version": "7.1.6",
+						"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+						"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+						"dev": true,
+						"requires": {
+								"fs.realpath": "^1.0.0",
+								"inflight": "^1.0.4",
+								"inherits": "2",
+								"minimatch": "^3.0.4",
+								"once": "^1.3.0",
+								"path-is-absolute": "^1.0.0"
+						}
+				},
+				"graceful-fs": {
+						"version": "4.2.6",
+						"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+						"integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
 						"dev": true
 				},
 				"has": {
@@ -148,6 +634,22 @@
 						"integrity": "sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg==",
 						"dev": true
 				},
+				"inflight": {
+						"version": "1.0.6",
+						"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+						"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+						"dev": true,
+						"requires": {
+								"once": "^1.3.0",
+								"wrappy": "1"
+						}
+				},
+				"inherits": {
+						"version": "2.0.4",
+						"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+						"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+						"dev": true
+				},
 				"is-core-module": {
 						"version": "2.2.0",
 						"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
@@ -156,6 +658,76 @@
 						"requires": {
 								"has": "^1.0.3"
 						}
+				},
+				"is-module": {
+						"version": "1.0.0",
+						"resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+						"integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
+						"dev": true
+				},
+				"is-reference": {
+						"version": "1.2.1",
+						"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+						"integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+						"dev": true,
+						"requires": {
+								"@types/estree": "*"
+						}
+				},
+				"is-valid-identifier": {
+						"version": "2.0.2",
+						"resolved": "https://registry.npmjs.org/is-valid-identifier/-/is-valid-identifier-2.0.2.tgz",
+						"integrity": "sha512-mpS5EGqXOwzXtKAg6I44jIAqeBfntFLxpAth1rrKbxtKyI6LPktyDYpHBI+tHlduhhX/SF26mFXmxQu995QVqg==",
+						"dev": true,
+						"requires": {
+								"assert": "^1.4.1"
+						}
+				},
+				"jsonfile": {
+						"version": "6.1.0",
+						"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+						"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+						"dev": true,
+						"requires": {
+								"graceful-fs": "^4.1.6",
+								"universalify": "^2.0.0"
+						}
+				},
+				"kleur": {
+						"version": "4.1.4",
+						"resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
+						"integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==",
+						"dev": true
+				},
+				"locate-character": {
+						"version": "2.0.5",
+						"resolved": "https://registry.npmjs.org/locate-character/-/locate-character-2.0.5.tgz",
+						"integrity": "sha512-n2GmejDXtOPBAZdIiEFy5dJ5N38xBCXLNOtw2WpB9kGh6pnrEuKlwYI+Tkpofc4wDtVXHtoAOJaMRlYG/oYaxg==",
+						"dev": true
+				},
+				"magic-string": {
+						"version": "0.25.7",
+						"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+						"integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+						"dev": true,
+						"requires": {
+								"sourcemap-codec": "^1.4.4"
+						}
+				},
+				"minimatch": {
+						"version": "3.0.4",
+						"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+						"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+						"dev": true,
+						"requires": {
+								"brace-expansion": "^1.1.7"
+						}
+				},
+				"mkdirp": {
+						"version": "1.0.4",
+						"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+						"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+						"dev": true
 				},
 				"mri": {
 						"version": "1.1.6",
@@ -173,6 +745,33 @@
 						"version": "3.1.22",
 						"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.22.tgz",
 						"integrity": "sha512-/2ZUaJX2ANuLtTvqTlgqBQNJoQO398KyJgZloL0PZkC0dpysjncRUPsFe3DUPzz/y3h+u7C46np8RMuvF3jsSQ==",
+						"dev": true
+				},
+				"object-assign": {
+						"version": "4.1.1",
+						"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+						"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+						"dev": true
+				},
+				"once": {
+						"version": "1.4.0",
+						"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+						"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+						"dev": true,
+						"requires": {
+								"wrappy": "1"
+						}
+				},
+				"path-browserify": {
+						"version": "1.0.1",
+						"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+						"integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+						"dev": true
+				},
+				"path-is-absolute": {
+						"version": "1.0.1",
+						"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+						"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 						"dev": true
 				},
 				"path-parse": {
@@ -234,6 +833,15 @@
 								"path-parse": "^1.0.6"
 						}
 				},
+				"rimraf": {
+						"version": "3.0.2",
+						"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+						"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+						"dev": true,
+						"requires": {
+								"glob": "^7.1.3"
+						}
+				},
 				"rollup": {
 						"version": "2.44.0",
 						"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.44.0.tgz",
@@ -241,6 +849,15 @@
 						"dev": true,
 						"requires": {
 								"fsevents": "~2.3.1"
+						}
+				},
+				"rollup-plugin-polyfill-node": {
+						"version": "0.5.0",
+						"resolved": "https://registry.npmjs.org/rollup-plugin-polyfill-node/-/rollup-plugin-polyfill-node-0.5.0.tgz",
+						"integrity": "sha512-CYPf4vKeZG5w/Ut7TR1lEMKiBT2pHfj1RLnk92whXKFtT8IGkm+TydwgDNpgTXBCI4V528YijyFVMz4dKcR3AA==",
+						"dev": true,
+						"requires": {
+								"@rollup/plugin-inject": "^4.0.0"
 						}
 				},
 				"sade": {
@@ -262,6 +879,36 @@
 						"version": "0.7.3",
 						"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
 						"integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+						"dev": true
+				},
+				"source-map-support": {
+						"version": "0.5.19",
+						"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+						"integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+						"dev": true,
+						"requires": {
+								"buffer-from": "^1.0.0",
+								"source-map": "^0.6.0"
+						},
+						"dependencies": {
+								"source-map": {
+										"version": "0.6.1",
+										"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+										"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+										"dev": true
+								}
+						}
+				},
+				"sourcemap-codec": {
+						"version": "1.4.8",
+						"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+						"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+						"dev": true
+				},
+				"strict-event-emitter-types": {
+						"version": "2.0.0",
+						"resolved": "https://registry.npmjs.org/strict-event-emitter-types/-/strict-event-emitter-types-2.0.0.tgz",
+						"integrity": "sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA==",
 						"dev": true
 				},
 				"supports-color": {
@@ -291,6 +938,23 @@
 						"integrity": "sha512-kGJ14aXcQEcyteoIijDDPvMDIq/CpkMbkW/wAFISD//KGXu7Y5fi4T/6/whKgHZFY1vw52D1SrTwN34uvTjdjw==",
 						"dev": true
 				},
+				"terser": {
+						"version": "5.6.1",
+						"resolved": "https://registry.npmjs.org/terser/-/terser-5.6.1.tgz",
+						"integrity": "sha512-yv9YLFQQ+3ZqgWCUk+pvNJwgUTdlIxUk1WTN+RnaFJe2L7ipG2csPT0ra2XRm7Cs8cxN7QXmK1rFzEwYEQkzXw==",
+						"dev": true,
+						"requires": {
+								"commander": "^2.20.0",
+								"source-map": "~0.7.2",
+								"source-map-support": "~0.5.19"
+						}
+				},
+				"totalist": {
+						"version": "2.0.0",
+						"resolved": "https://registry.npmjs.org/totalist/-/totalist-2.0.0.tgz",
+						"integrity": "sha512-+Y17F0YzxfACxTyjfhnJQEe7afPA0GSpYlFkl2VFMxYP7jshQf9gXV7cH47EfToBumFThfKBvfAcoUn6fdNeRQ==",
+						"dev": true
+				},
 				"tslib": {
 						"version": "2.1.0",
 						"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
@@ -302,6 +966,51 @@
 						"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.3.tgz",
 						"integrity": "sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==",
 						"dev": true
+				},
+				"universalify": {
+						"version": "2.0.0",
+						"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+						"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+						"dev": true
+				},
+				"util": {
+						"version": "0.10.3",
+						"resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+						"integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+						"dev": true,
+						"requires": {
+								"inherits": "2.0.1"
+						},
+						"dependencies": {
+								"inherits": {
+										"version": "2.0.1",
+										"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+										"integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+										"dev": true
+								}
+						}
+				},
+				"uvu": {
+						"version": "0.5.1",
+						"resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.1.tgz",
+						"integrity": "sha512-JGxttnOGDFs77FaZ0yMUHIzczzQ5R1IlDeNW6Wymw6gAscwMdAffVOP6TlxLIfReZyK8tahoGwWZaTCJzNFDkg==",
+						"dev": true,
+						"requires": {
+								"dequal": "^2.0.0",
+								"diff": "^5.0.0",
+								"kleur": "^4.0.3",
+								"sade": "^1.7.3",
+								"totalist": "^2.0.0"
+						}
+				},
+				"validate-npm-package-name": {
+						"version": "3.0.0",
+						"resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+						"integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
+						"dev": true,
+						"requires": {
+								"builtins": "^1.0.3"
+						}
 				},
 				"vite": {
 						"version": "2.1.3",
@@ -315,6 +1024,18 @@
 								"resolve": "^1.19.0",
 								"rollup": "^2.38.5"
 						}
+				},
+				"vm2": {
+						"version": "3.9.3",
+						"resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.3.tgz",
+						"integrity": "sha512-smLS+18RjXYMl9joyJxMNI9l4w7biW8ilSDaVRvFBDwOH8P0BK1ognFQTpg0wyQ6wIKLTblHJvROW692L/E53Q==",
+						"dev": true
+				},
+				"wrappy": {
+						"version": "1.0.2",
+						"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+						"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+						"dev": true
 				}
 		}
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@feltcoop/gro": "^0.16.0",
+    "@feltcoop/gro": "^0.17.0",
     "@sveltejs/adapter-static": "^1.0.0-next.4",
     "@sveltejs/kit": "next",
     "prettier": "~2.2.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {},
   "devDependencies": {
+    "@feltcoop/gro": "^0.16.0",
     "@sveltejs/adapter-static": "^1.0.0-next.4",
     "@sveltejs/kit": "next",
     "prettier": "~2.2.1",

--- a/src/app.html
+++ b/src/app.html
@@ -2,7 +2,6 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<link rel="icon" href="/favicon.ico" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		%svelte.head%
 	</head>

--- a/src/routes/$layout.svelte
+++ b/src/routes/$layout.svelte
@@ -2,4 +2,8 @@
 	import '../app.css';
 </script>
 
+<svelte:head>
+	<link rel="icon" href="/favicon.ico" />
+</svelte:head>
+
 <slot />

--- a/src/routes/$layout.svelte
+++ b/src/routes/$layout.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <svelte:head>
-	<link rel="icon" href="/favicon.ico" />
+	<link rel="icon" href="favicon.ico" />
 </svelte:head>
 
 <slot />

--- a/svelte.config.cjs
+++ b/svelte.config.cjs
@@ -10,8 +10,6 @@ module.exports = {
 
 		// because the default '_app' is ignored by GitHub pages by default
 		appDir: 'app',
-		// because we're mounted in production at feltcoop.github.io/felt
-		paths: {base: process.env.NODE_ENV === 'production' ? '/felt' : ''},
 
 		// hydrate the <div id="svelte"> element in src/app.html
 		target: '#svelte',

--- a/svelte.config.cjs
+++ b/svelte.config.cjs
@@ -9,10 +9,7 @@ module.exports = {
 		adapter: staticAdapter(),
 
 		appDir: 'app', // because _app is ignored by GitHub pages by default
-		paths: {
-			// TODO derive from `package.json`, stripping namespace as necessary
-			base: process.env.NODE_ENV === 'production' ? '/felt' : '',
-		},
+		paths: {base: process.env.NODE_ENV === 'production' ? '/felt' : ''},
 
 		// hydrate the <div id="svelte"> element in src/app.html
 		target: '#svelte',

--- a/svelte.config.cjs
+++ b/svelte.config.cjs
@@ -8,7 +8,9 @@ module.exports = {
 	kit: {
 		adapter: staticAdapter(),
 
-		appDir: 'app', // because _app is ignored by GitHub pages by default
+		// because the default '_app' is ignored by GitHub pages by default
+		appDir: 'app',
+		// because we're mounted in production at feltcoop.github.io/felt
 		paths: {base: process.env.NODE_ENV === 'production' ? '/felt' : ''},
 
 		// hydrate the <div id="svelte"> element in src/app.html

--- a/svelte.config.cjs
+++ b/svelte.config.cjs
@@ -8,6 +8,12 @@ module.exports = {
 	kit: {
 		adapter: staticAdapter(),
 
+		appDir: 'app', // because _app is ignored by GitHub pages by default
+		paths: {
+			// TODO derive from `package.json`, stripping namespace as necessary
+			base: process.env.NODE_ENV === 'production' ? '/felt' : '',
+		},
+
 		// hydrate the <div id="svelte"> element in src/app.html
 		target: '#svelte',
 


### PR DESCRIPTION
This tracks the steps taken to deploy to GitHub pages. See [Gro's deployment documentation](https://github.com/feltcoop/gro/blob/main/src/docs/deploy.md) for more and the live website at <https://www.felt.dev/>

in this PR:

- install `@feltcoop/gro`
- configure for GitHub pages, including the base url and static contents directory, because by default SvelteKit's primary `_app` output is ignored by GitHub pages, so it's renamed `app`, which I like more anyway

I then ran:

```
gro deploy
```

I ran it again from this branch, because by default it switches to main:

```
gro deploy --branch static-deploy
```

I then turned on GitHub pages to the `deploy` branch, which is the Gro default.

<https://www.felt.dev/>

In the future we can run `gro deploy` whenever. It's a no-op if nothing has changed.

You can also simulate production now with the latest version of Gro by running:

```bash
gro build # or gro deploy, both build dist/
gro start
```