### PR TITLE
remove nav as public export

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # changelog
 
+## 0.1.1
+
+- remove `Nav.svelte` from the public API
+
 ## 0.1.0
 
 - gogo

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,5 +6,4 @@ export * as icons from './lib/icons.js';
 // components
 export {default as FeltHeart} from './lib/FeltHeart.svelte';
 export {default as Icons} from './lib/Icons.svelte';
-export {default as Nav} from './lib/Nav.svelte';
 export {default as PendingAnimation} from './lib/PendingAnimation.svelte';


### PR DESCRIPTION
This removes the `Nav` component as an export from the project. Currently the code breaks in non-SvelteKit projects because this component is using the SvelteKit import `$app/stores`. We may have to support a separate entrypoint for SvelteKit-enabled modules. e.g. `@feltcoop/felt/kit` or `@feltcoop/felt/svelte-kit` or something. (not now, later)

Removing the export makes sense too, because `Nav`, as written, is specific to this app. It's odd that it's side by side with other modules in `src/lib` - I'm not sure what structure we ultimately want here. Bigger discussion we'll punt for now. I'm not sure I like SvelteKit's `src/lib/` namespacing, at least not as a wrapper for all sub packages - I've enjoyed organizing things as `src/{domain}`. Right now I do like putting `Nav` in `src/lib/` because it's app-specific, but the extra nesting feels like a drag for generic public modules and packages.

I'll cut a new version after this so Felt should start working with non-SvelteKit projects. SvelteKit currently errors for non-CJS node modules, while Vite alone works -- I'll follow up on this soon.
