### PR TITLE
simplify package json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,12 +10,9 @@
   },
   "type": "module",
   "main": "./dist/index.js",
-  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
-    ".": {
-      "import": "./dist/index.js"
-    },
+    ".": "./dist/index.js",
     "./package.json": "./package.json"
   },
   "files": [


### PR DESCRIPTION
This simplifies the `package.json` usage of the `"exports"` key given that we don't use the [conditional exports](https://nodejs.org/api/packages.html#packages_conditional_exports). I'm also tentatively removing the `"module"` field, which is non-standard and not necessary for our tools. The `"type": "module"` field should be the only thing modern tools need, I think.

- [x] ensure removing `"module"` works with Vite and SvelteKit