### PR TITLE
remove remaining Svelte components from public API

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ## 0.1.2
 
-- remove remaining Svelte components until we figure out the full process
+- remove remaining Svelte components from public API until the full process is ready
   ([#29](https://github.com/feltcoop/felt/pull/29))
 
 ## 0.1.1

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # changelog
 
+## 0.1.2
+
+- remove remaining Svelte components until we figure out the full process
+  ([#29](https://github.com/feltcoop/felt/pull/29))
+
 ## 0.1.1
 
 - remove `Nav.svelte` from the public API

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.1",
       "license": "MIT",
       "devDependencies": {
-        "@feltcoop/gro": "^0.24.1",
+        "@feltcoop/gro": "^0.25.2",
         "@sveltejs/adapter-static": "^1.0.0-next.4",
         "@sveltejs/kit": "next",
         "prettier": "~2.2.1",
@@ -25,9 +25,9 @@
       }
     },
     "node_modules/@feltcoop/gro": {
-      "version": "0.24.1",
-      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.24.1.tgz",
-      "integrity": "sha512-cYrkPfa9F8THq4f2Q8DainJJDg6T3/J9R/3im7JOuYj6LdImJ+nFbnZmrzfYUfr0a3DA1rqCs2AixsixZUoA0g==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.25.2.tgz",
+      "integrity": "sha512-GpHLgYIr8lMqK+7mJtnyKcc+cZOUbCTiyKu7g5sNX0+X4DtCYtWlXKl8QyQeDRB+W7DuqvFbYhQud/vDz6zefg==",
       "dev": true,
       "dependencies": {
         "@lukeed/uuid": "^2.0.0",
@@ -1405,9 +1405,9 @@
   },
   "dependencies": {
     "@feltcoop/gro": {
-      "version": "0.24.1",
-      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.24.1.tgz",
-      "integrity": "sha512-cYrkPfa9F8THq4f2Q8DainJJDg6T3/J9R/3im7JOuYj6LdImJ+nFbnZmrzfYUfr0a3DA1rqCs2AixsixZUoA0g==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.25.2.tgz",
+      "integrity": "sha512-GpHLgYIr8lMqK+7mJtnyKcc+cZOUbCTiyKu7g5sNX0+X4DtCYtWlXKl8QyQeDRB+W7DuqvFbYhQud/vDz6zefg==",
       "dev": true,
       "requires": {
         "@lukeed/uuid": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test": "gro test"
   },
   "devDependencies": {
-    "@feltcoop/gro": "^0.24.1",
+    "@feltcoop/gro": "^0.25.2",
     "@sveltejs/adapter-static": "^1.0.0-next.4",
     "@sveltejs/kit": "next",
     "prettier": "~2.2.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,3 @@
 // and this defines the package's public API:
 
 export * as icons from './lib/icons.js';
-
-// components
-export {default as FeltHeart} from './lib/FeltHeart.svelte';
-export {default as Icons} from './lib/Icons.svelte';
-export {default as PendingAnimation} from './lib/PendingAnimation.svelte';


### PR DESCRIPTION
This removes the exported Svelte components from the published package entrypoint. We're going to need to figure out a few things specific to Svelte here, so for now let's keep it simple and export only TypeScript for now.

It also upgrades Gro to the latest.