### PR TITLE
add second confirmation diaglog to consentful revertible

### DIFF
--- a/src/onboard/consentful/Revertible.svelte
+++ b/src/onboard/consentful/Revertible.svelte
@@ -17,7 +17,7 @@
 	</p>
 	<button on:click={() => back()}>← go back and learn</button>
 	<blockquote>🌈✨ if you don't know the deal, it's not consentful✨✨</blockquote>
-	<button on:click={() => (understood = true)} disabled={understood}>yes I understand →</button>
+	<button on:click={() => (understood = true)} disabled={understood}> yes I understand → </button>
 	{#if understood}
 		<p>
 			Here's <a href="/deal">a link to the documents</a> for the future, and you can always find

--- a/src/onboard/consentful/Revertible.svelte
+++ b/src/onboard/consentful/Revertible.svelte
@@ -17,7 +17,7 @@
 	</p>
 	<button on:click={() => back()}>← go back and learn</button>
 	<blockquote>🌈✨ if you don't know the deal, it's not consentful✨✨</blockquote>
-	<button on:click={() => (understood = true)}>yes I understand →</button>
+	<button on:click={() => (understood = true)} disabled={understood}>yes I understand →</button>
 	{#if understood}
 		<p>
 			Here's <a href="/deal">a link to the documents</a> for the future, and you can always find

--- a/src/onboard/consentful/Revertible.svelte
+++ b/src/onboard/consentful/Revertible.svelte
@@ -5,6 +5,8 @@
 	export let data: Onboard_Data;
 	export let done: () => void;
 	export let back: () => void;
+
+	let understood = false;
 </script>
 
 <Markup>
@@ -15,5 +17,12 @@
 	</p>
 	<button on:click={() => back()}>← go back and learn</button>
 	<blockquote>🌈✨ if you don't know the deal, it's not consentful✨✨</blockquote>
-	<button on:click={() => done()}>yes I understand →</button>
+	<button on:click={() => (understood = true)}>yes I understand →</button>
+	{#if understood}
+		<p>
+			Here's <a href="/deal">a link to the documents</a> for the future, and you can always find
+			help in your <a href="/account">account settings</a>
+			<button class="inline" on:click={() => done()}>got it →</button>
+		</p>
+	{/if}
 </Markup>

--- a/src/onboard/consentful/Revertible.svelte
+++ b/src/onboard/consentful/Revertible.svelte
@@ -22,7 +22,7 @@
 		<p>
 			Here's <a href="/deal">a link to the documents</a> for the future, and you can always find
 			help in your <a href="/account">account settings</a>
-			<button class="inline" on:click={() => done()}>got it →</button>
+			<button class="inline" on:click={() => done()}> got it → </button>
 		</p>
 	{/if}
 </Markup>


### PR DESCRIPTION
This makes the consentful revertible step slightly more frictionful & informative, by popping up a second dialog with final confirmation and additional information. Maybe overkill? It's deployed.