### PR TITLE
add content for `consentful-unburdensome`

### DIFF
--- a/src/onboard/consentful/Unburdensome.svelte
+++ b/src/onboard/consentful/Unburdensome.svelte
@@ -1,9 +1,16 @@
 <script lang="ts">
 	import type {Onboard_Data} from '../onboard';
+	import Markup from '$lib/Markup.svelte';
 
 	export let data: Onboard_Data;
 	export let done: () => void;
 	export let back: () => void;
 </script>
 
-<button on:click={() => done()}> →</button>
+<Markup>
+	<h2>welcome to Felt.dev!</h2>
+</Markup>
+
+<button on:click={() => done()}>
+	<Markup>let's go →</Markup>
+</button>

--- a/src/onboard/consentful/Unburdensome.svelte
+++ b/src/onboard/consentful/Unburdensome.svelte
@@ -11,6 +11,8 @@
 	<h2>welcome to Felt.dev!</h2>
 </Markup>
 
+<blockquote>need help? <a href="https://www.felt.dev/help">felt.dev/help</a></blockquote>
+
 <button on:click={() => done()}>
 	<Markup>let's go →</Markup>
 </button>

--- a/src/routes/help.svelte
+++ b/src/routes/help.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import Help_Message from '$lib/Help_Message.svelte';
+</script>
+
+<div class="column">
+	<Help_Message text="todo" />
+	<h2>
+		<a href="https://github.com/feltcoop/felt/issues">github.com/feltcoop/felt/issues</a>
+	</h2>
+</div>
+
+<style>
+	.column {
+		margin: auto;
+	}
+	h2 {
+		padding: var(--spacing_lg) 0;
+		text-align: center;
+	}
+</style>


### PR DESCRIPTION
It's minimal, just un-breaks the experience.

Mirrors the `end` page content

addresses but doesn't necessarily close https://github.com/feltcoop/felt/issues/43

also adds a help page at felt.dev/help