### PR TITLE
change description field name to summary

### DIFF
--- a/src/consent/Consent_Principle_View.svelte
+++ b/src/consent/Consent_Principle_View.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
 	import type {Consent_Principle} from './consent';
 
-	// TODO display `description` property, see `./consent` for why it's not there
-
 	// TODO remove/rename the `_View` in `Consent_Principle_View` probably,
 	// but how to avoid name clash with interface?
 
@@ -11,4 +9,4 @@
 
 <h2>{principle.type}</h2>
 :
-{principle.description}
+{principle.summary}

--- a/src/consent/consent.ts
+++ b/src/consent/consent.ts
@@ -2,7 +2,7 @@
 
 copied from: https://consentful.systems/
 
-TODO add descriptions
+TODO add summarys
 
 TODO should "affirmative consent" instead of "consent" in some places?
 
@@ -27,15 +27,15 @@ export const consent_principle_types: Consent_Principle_Type[] = [
 
 export interface Consent_Principle {
 	type: Consent_Principle_Type;
-	description: string;
+	summary: string;
 }
 
 export const consent_principles_data: Consent_Principle[] = [
-	{type: 'voluntary', description: 'TODO'},
-	{type: 'informed', description: 'TODO'},
-	{type: 'revertible', description: 'TODO'},
-	{type: 'specific', description: 'TODO'},
-	{type: 'unburdensome', description: 'TODO'},
+	{type: 'voluntary', summary: 'TODO'},
+	{type: 'informed', summary: 'TODO'},
+	{type: 'revertible', summary: 'TODO'},
+	{type: 'specific', summary: 'TODO'},
+	{type: 'unburdensome', summary: 'TODO'},
 ];
 
 const [voluntary, informed, revertible, specific, unburdensome] = consent_principles_data;


### PR DESCRIPTION
This changes the `description` property of `Consent_Principle` to `summary` to match ActivityStreams: https://ryanatkn.github.io/corpus-activity-streams/#summary