### PR TITLE
update terminal color api and add missing util to build

### DIFF
--- a/src/gro.config.ts
+++ b/src/gro.config.ts
@@ -19,6 +19,7 @@ const files = [
 	'util/object.ts',
 	'util/obtainable.ts',
 	'util/path.ts',
+	'util/path_parsing.ts',
 	'util/print.ts',
 	'util/process.ts',
 	'util/random.ts',

--- a/src/gro.config.ts
+++ b/src/gro.config.ts
@@ -35,8 +35,8 @@ export const config: GroConfigCreator = async () => {
 		adapt: async () => [
 			// TODO this is bugged in Gro, could be hackfixed with a simple in-between adapter but w/e --
 			// for now to publish Felt to npm, these two lines need to be swapped
-			(await import('@feltcoop/gro/dist/adapt/gro-adapter-sveltekit-frontend.js')).createAdapter(),
-			// (await import('@feltcoop/gro/dist/adapt/gro-adapter-node-library.js')).createAdapter(),
+			// (await import('@feltcoop/gro/dist/adapt/gro-adapter-sveltekit-frontend.js')).createAdapter(),
+			(await import('@feltcoop/gro/dist/adapt/gro-adapter-node-library.js')).createAdapter(),
 		],
 	};
 	return partial;

--- a/src/util/terminal.ts
+++ b/src/util/terminal.ts
@@ -1,10 +1,29 @@
 import {red, yellow, green, cyan, blue, magenta} from 'kleur/colors';
 
-export * from 'kleur/colors';
+export {
+	bold,
+	gray,
+	black,
+	white,
+	red,
+	yellow,
+	green,
+	cyan,
+	blue,
+	magenta,
+	bgRed as bg_red,
+	bgYellow as bg_yellow,
+	bgGreen as bg_green,
+	bgCyan as bg_cyan,
+	bgBlue as bg_blue,
+	bgMagenta as bg_magenta,
+	bgBlack as bg_black,
+	bgWhite as bg_white,
+} from 'kleur/colors';
 
-const rainbow_colors = [red, yellow, green, cyan, blue, magenta];
+const rainbowColors = [red, yellow, green, cyan, blue, magenta];
 
 export const rainbow = (str: string): string =>
 	Array.from(str)
-		.map((char, i) => rainbow_colors[i % rainbow_colors.length](char))
+		.map((char, i) => rainbowColors[i % rainbowColors.length](char))
 		.join('');

--- a/src/util/terminal.ts
+++ b/src/util/terminal.ts
@@ -1,16 +1,7 @@
 import {red, yellow, green, cyan, blue, magenta} from 'kleur/colors';
 
+export * from 'kleur/colors';
 export {
-	bold,
-	gray,
-	black,
-	white,
-	red,
-	yellow,
-	green,
-	cyan,
-	blue,
-	magenta,
 	bgRed as bg_red,
 	bgYellow as bg_yellow,
 	bgGreen as bg_green,
@@ -21,9 +12,9 @@ export {
 	bgWhite as bg_white,
 } from 'kleur/colors';
 
-const rainbowColors = [red, yellow, green, cyan, blue, magenta];
+const rainbow_colors = [red, yellow, green, cyan, blue, magenta];
 
 export const rainbow = (str: string): string =>
 	Array.from(str)
-		.map((char, i) => rainbowColors[i % rainbowColors.length](char))
+		.map((char, i) => rainbow_colors[i % rainbow_colors.length](char))
 		.join('');


### PR DESCRIPTION
We're re-exporting `kleur` here, and this maps the `bgColorname` exports to `bg_colorname`. 

Going forward I'm not 100% on this re-exporting pattern, but it's fine for now.