### PR TITLE
fix publishing and update gro adapters and plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 npm i @feltcoop/felt
 ```
 
-The top-level API ([see src/index.ts](src/index.ts)) is a work in progress:
+The top-level API ([see src/lib/index.ts](src/lib/index.ts)) is a work in progress:
 
 ```ts
 import type {Result} from '@feltcoop/felt';

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # changelog
 
+## 0.3.0
+
+- **break**: swap the names of `spawn` and `spawn_process`
+  ([#63](https://github.com/feltcoop/felt/pull/63))
+
 ## 0.2.2
 
 - fix another issue with published types

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 
 - **break**: swap the names of `spawn` and `spawn_process`
   ([#63](https://github.com/feltcoop/felt/pull/63))
+- upgrade Gro to 0.28.0
+  ([#63](https://github.com/feltcoop/felt/pull/63))
 
 ## 0.2.2
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@
 
 - **break**: swap the names of `spawn` and `spawn_process`
   ([#63](https://github.com/feltcoop/felt/pull/63))
+- **break**: rename `util/timings.ts` from `util/time.ts`
+  ([#63](https://github.com/feltcoop/felt/pull/63))
+- **break**: rename `Timings.get_all` from `Timings.getAll`
+  ([#63](https://github.com/feltcoop/felt/pull/63))
 - upgrade Gro to 0.28.0
   ([#63](https://github.com/feltcoop/felt/pull/63))
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,9 @@
 
 - **break**: swap the names of `spawn` and `spawn_process`
   ([#63](https://github.com/feltcoop/felt/pull/63))
+- **break**: rename `spawn_restartable_process` from `create_restartable_process`
+  and remove its `delay` arg
+  ([#63](https://github.com/feltcoop/felt/pull/63))
 - **break**: rename `util/timings.ts` from `util/time.ts`
   ([#63](https://github.com/feltcoop/felt/pull/63))
 - **break**: rename `Timings.get_all` from `Timings.getAll`

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "kleur": "^4.1.4"
       },
       "devDependencies": {
-        "@feltcoop/gro": "^0.27.3",
+        "@feltcoop/gro": "^0.28.0",
         "@sveltejs/adapter-static": "^1.0.0-next.13",
         "@sveltejs/kit": "^1.0.0-next.115",
         "@xstate/svelte": "^0.1.0",
@@ -33,9 +33,9 @@
       }
     },
     "node_modules/@feltcoop/felt": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.2.0.tgz",
-      "integrity": "sha512-cWtXGH5tbKRJlljTEmYWDppcBdnK5e7oJ2FWBCKBpkkGHTwMQy2HrTney951nxAgbmu41K7cJzDjS2WnjbuBvg==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.2.2.tgz",
+      "integrity": "sha512-t+pVEW5JgtmtJGebZAqZzYk4wz2xHGz5Ki4oaqOBHE1wJsR5VeFqcx5zt9DA7TUCgdedrBlu2g2TAo2wvHmX2g==",
       "dev": true,
       "dependencies": {
         "@lukeed/uuid": "^2.0.0",
@@ -47,12 +47,12 @@
       }
     },
     "node_modules/@feltcoop/gro": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.27.3.tgz",
-      "integrity": "sha512-1rjnruvCPwjOn2/eRXcR8RVQ0LtSJZGSlgsRDk52PvvpNN8IJPby3TdGbasWqKwFUyUFmy5K/gt1nrwRkeXrQg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.28.0.tgz",
+      "integrity": "sha512-MtXB7U28/ToCw1i0m85QwhdZ/4aGtoE9YW4QInB5MrLH7tPJXGhwUkSgt+YpwHnLy6WRMBs4SWYgitJSQgG0xA==",
       "dev": true,
       "dependencies": {
-        "@feltcoop/felt": "^0.2.0",
+        "@feltcoop/felt": "^0.2.2",
         "@rollup/plugin-commonjs": "^18.0.0",
         "@rollup/plugin-node-resolve": "^11.2.1",
         "@rollup/pluginutils": "^4.1.0",
@@ -1405,9 +1405,9 @@
   },
   "dependencies": {
     "@feltcoop/felt": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.2.0.tgz",
-      "integrity": "sha512-cWtXGH5tbKRJlljTEmYWDppcBdnK5e7oJ2FWBCKBpkkGHTwMQy2HrTney951nxAgbmu41K7cJzDjS2WnjbuBvg==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.2.2.tgz",
+      "integrity": "sha512-t+pVEW5JgtmtJGebZAqZzYk4wz2xHGz5Ki4oaqOBHE1wJsR5VeFqcx5zt9DA7TUCgdedrBlu2g2TAo2wvHmX2g==",
       "dev": true,
       "requires": {
         "@lukeed/uuid": "^2.0.0",
@@ -1416,12 +1416,12 @@
       }
     },
     "@feltcoop/gro": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.27.3.tgz",
-      "integrity": "sha512-1rjnruvCPwjOn2/eRXcR8RVQ0LtSJZGSlgsRDk52PvvpNN8IJPby3TdGbasWqKwFUyUFmy5K/gt1nrwRkeXrQg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.28.0.tgz",
+      "integrity": "sha512-MtXB7U28/ToCw1i0m85QwhdZ/4aGtoE9YW4QInB5MrLH7tPJXGhwUkSgt+YpwHnLy6WRMBs4SWYgitJSQgG0xA==",
       "dev": true,
       "requires": {
-        "@feltcoop/felt": "^0.2.0",
+        "@feltcoop/felt": "^0.2.2",
         "@rollup/plugin-commonjs": "^18.0.0",
         "@rollup/plugin-node-resolve": "^11.2.1",
         "@rollup/pluginutils": "^4.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "kleur": "^4.1.4"
       },
       "devDependencies": {
-        "@feltcoop/gro": "^0.28.0",
+        "@feltcoop/gro": "^0.28.1",
         "@sveltejs/adapter-static": "^1.0.0-next.13",
         "@sveltejs/kit": "^1.0.0-next.115",
         "@xstate/svelte": "^0.1.0",
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@feltcoop/gro": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.28.0.tgz",
-      "integrity": "sha512-MtXB7U28/ToCw1i0m85QwhdZ/4aGtoE9YW4QInB5MrLH7tPJXGhwUkSgt+YpwHnLy6WRMBs4SWYgitJSQgG0xA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.28.1.tgz",
+      "integrity": "sha512-v/WAQ/9twdk+bA/7KaIXXSpdPsozvn7F7ocdS8hxUzAsFR1oUKiP0HxgWmONvVvxHzHSM3ZQHjwkuS2m8CGY/g==",
       "dev": true,
       "dependencies": {
         "@feltcoop/felt": "^0.2.2",
@@ -1416,9 +1416,9 @@
       }
     },
     "@feltcoop/gro": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.28.0.tgz",
-      "integrity": "sha512-MtXB7U28/ToCw1i0m85QwhdZ/4aGtoE9YW4QInB5MrLH7tPJXGhwUkSgt+YpwHnLy6WRMBs4SWYgitJSQgG0xA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.28.1.tgz",
+      "integrity": "sha512-v/WAQ/9twdk+bA/7KaIXXSpdPsozvn7F7ocdS8hxUzAsFR1oUKiP0HxgWmONvVvxHzHSM3ZQHjwkuS2m8CGY/g==",
       "dev": true,
       "requires": {
         "@feltcoop/felt": "^0.2.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "gro test"
   },
   "devDependencies": {
-    "@feltcoop/gro": "^0.27.3",
+    "@feltcoop/gro": "^0.28.0",
     "@sveltejs/adapter-static": "^1.0.0-next.13",
     "@sveltejs/kit": "^1.0.0-next.115",
     "@xstate/svelte": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "gro test"
   },
   "devDependencies": {
-    "@feltcoop/gro": "^0.28.0",
+    "@feltcoop/gro": "^0.28.1",
     "@sveltejs/adapter-static": "^1.0.0-next.13",
     "@sveltejs/kit": "^1.0.0-next.115",
     "@xstate/svelte": "^0.1.0",

--- a/src/gro.config.ts
+++ b/src/gro.config.ts
@@ -34,10 +34,6 @@ const files = [
 export const config: Gro_Config_Creator = async () => {
 	const partial: Gro_Config_Partial = {
 		builds: [{name: 'library', platform: 'node', input: files}],
-		adapt: async () => [
-			(await import('@feltcoop/gro/dist/adapt/gro-adapter-sveltekit-frontend.js')).create_adapter(),
-			(await import('@feltcoop/gro/dist/adapt/gro-adapter-node-library.js')).create_adapter(),
-		],
 	};
 	return partial;
 };

--- a/src/gro.config.ts
+++ b/src/gro.config.ts
@@ -26,7 +26,7 @@ const files = [
 	'lib/util/random.ts',
 	'lib/util/string.ts',
 	'lib/util/terminal.ts',
-	'lib/util/time.ts',
+	'lib/util/timings.ts',
 	'lib/util/types.ts',
 	'lib/util/uuid.ts',
 ];

--- a/src/gro.config.ts
+++ b/src/gro.config.ts
@@ -4,7 +4,6 @@ const files = [
 	// top level API: `import {...} from '@feltcoop/felt';`
 	'lib/index.ts',
 
-	// TODO refactor
 	// deep imports available to external consumers
 	'lib/util/array.ts',
 	'lib/util/async.ts',

--- a/src/gro.config.ts
+++ b/src/gro.config.ts
@@ -2,7 +2,7 @@ import type {Gro_Config_Creator, Gro_Config_Partial} from '@feltcoop/gro';
 
 const files = [
 	// top level API: `import {...} from '@feltcoop/felt';`
-	'index.ts',
+	'lib/index.ts',
 
 	// TODO refactor
 	// deep imports available to external consumers

--- a/src/gro.config.ts
+++ b/src/gro.config.ts
@@ -4,6 +4,7 @@ const files = [
 	// top level API: `import {...} from '@feltcoop/felt';`
 	'index.ts',
 
+	// TODO refactor
 	// deep imports available to external consumers
 	'lib/util/array.ts',
 	'lib/util/async.ts',
@@ -26,6 +27,7 @@ const files = [
 	'lib/util/string.ts',
 	'lib/util/terminal.ts',
 	'lib/util/time.ts',
+	'lib/util/types.ts',
 	'lib/util/uuid.ts',
 ];
 

--- a/src/gro.config.ts
+++ b/src/gro.config.ts
@@ -33,9 +33,7 @@ export const config: Gro_Config_Creator = async () => {
 	const partial: Gro_Config_Partial = {
 		builds: [{name: 'library', platform: 'node', input: files}],
 		adapt: async () => [
-			// TODO this is bugged in Gro, could be hackfixed with a simple in-between adapter but w/e --
-			// for now to publish Felt to npm, these two lines need to be swapped
-			// (await import('@feltcoop/gro/dist/adapt/gro-adapter-sveltekit-frontend.js')).create_adapter(),
+			(await import('@feltcoop/gro/dist/adapt/gro-adapter-sveltekit-frontend.js')).create_adapter(),
 			(await import('@feltcoop/gro/dist/adapt/gro-adapter-node-library.js')).create_adapter(),
 		],
 	};

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,5 +26,5 @@ export * from './lib/util/types.js';
 // 	configure_log_level,
 // 	print_log_label,
 // } from './util/log.js';
-// export {Timings, create_stopwatch} from './util/time.js';
-// export type {Stopwatch} from './util/time.js';
+// export {Timings, create_stopwatch} from './util/timings.js';
+// export type {Stopwatch} from './util/timings.js';

--- a/src/lib/Checkbox.svelte
+++ b/src/lib/Checkbox.svelte
@@ -5,6 +5,7 @@
 </script>
 
 <script lang="ts">
+	// TODO rethink this API, probably use events instead
 	export let checked: boolean;
 	export let on_change: ((checked: boolean) => void) | null = null;
 

--- a/src/lib/devmode.ts
+++ b/src/lib/devmode.ts
@@ -4,9 +4,9 @@ import type {Writable} from 'svelte/store';
 
 const KEY = {};
 
-export const use_devmode = (): Writable<boolean> => getContext(KEY);
+export const get_devmode = (): Writable<boolean> => getContext(KEY);
 
-export const provide_devmode = (value: boolean | Writable<boolean> = false): Writable<boolean> => {
+export const set_devmode = (value: boolean | Writable<boolean> = false): Writable<boolean> => {
 	const store = typeof value === 'boolean' ? writable(value) : value;
 	setContext(KEY, store);
 	return store;

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,9 +1,9 @@
 // public API for `@feltcoop/felt`:
 
-export * as icons from './lib/icons.js';
+export * as icons from './icons.js';
 
 // types
-export * from './lib/util/types.js';
+export * from './util/types.js';
 
 // TODO consider what top-level public API makes sense -
 // for now we're preferring deep imports to specific modules -

--- a/src/lib/onboard/End.svelte
+++ b/src/lib/onboard/End.svelte
@@ -2,9 +2,9 @@
 	import {grin} from '$lib/icons';
 	import Markup from '$lib/Markup.svelte';
 	import Credits from './Credits.svelte';
-	import {use_devmode} from '$lib/devmode';
+	import {get_devmode} from '$lib/devmode';
 
-	const devmode = use_devmode();
+	const devmode = get_devmode();
 </script>
 
 <Markup>

--- a/src/lib/onboard/Nav.svelte
+++ b/src/lib/onboard/Nav.svelte
@@ -2,13 +2,13 @@
 	import type {Onboard_Send, Onboard_State} from './onboard';
 	import Machine_Controls from '$lib/xstate/Machine_Controls.svelte';
 	import {onboard_machine} from './onboard';
-	import {use_devmode} from '$lib/devmode';
+	import {get_devmode} from '$lib/devmode';
 	import {arrow_left, arrow_right} from '$lib/icons';
 
 	export let state: Onboard_State;
 	export let send: Onboard_Send;
 
-	const devmode = use_devmode();
+	const devmode = get_devmode();
 
 	// console.log('onboard_machine', onboard_machine);
 	$: state_ids = Object.keys(onboard_machine.states);

--- a/src/lib/util/print.ts
+++ b/src/lib/util/print.ts
@@ -1,7 +1,7 @@
 import {gray, white, green, yellow} from './terminal.js';
 import {round} from './math.js';
 import {truncate} from './string.js';
-import type {Timings} from './time.js';
+import type {Timings} from './timings.js';
 import type {Logger} from './log.js';
 import {arrow_left} from '$lib/icons.js';
 
@@ -43,7 +43,7 @@ export const print_timing = (key: string | number, timing: number): string =>
 	`${print_ms(timing)} ${gray(arrow_left)} ${gray(key)}`;
 
 export const print_timings = (timings: Timings, log: Logger): void => {
-	for (const [key, timing] of timings.getAll()) {
+	for (const [key, timing] of timings.get_all()) {
 		log.trace(print_timing(key, timing));
 	}
 };

--- a/src/lib/util/process.ts
+++ b/src/lib/util/process.ts
@@ -81,7 +81,7 @@ interface To_Error_Label {
 // Wraps the normal Node `child_process.spawn` with graceful child shutdown behavior.
 // Also returns a convenient `closed` promise.
 // If you only need `closed`, prefer the shorthand function `spawn_process`.
-export const spawn = (
+export const spawn_process = (
 	command: string,
 	args: readonly string[] = [],
 	options?: SpawnOptions,
@@ -97,11 +97,11 @@ export const spawn = (
 	return {closed, child};
 };
 
-// This is just a convenient promise wrapper around `child_process.spawn`
-// that's intended for commands that have an end, not long running-processes.
-// Any more advanced usage should use `spawn` directly to have access to the `child`.
-export const spawn_process = (...args: Parameters<typeof spawn>): Promise<Spawn_Result> =>
-	spawn(...args).closed;
+// This is just a convenient promise wrapper around `spawn_process`
+// that's intended for commands that have an end, not long running-processes like watchers.
+// Any more advanced usage should use `spawn_process` directly for access to the `child` process.
+export const spawn = (...args: Parameters<typeof spawn_process>): Promise<Spawn_Result> =>
+	spawn_process(...args).closed;
 
 export const print_spawn_result = (result: Spawn_Result): string => {
 	if (result.ok) return 'ok';

--- a/src/lib/util/timings.test.ts
+++ b/src/lib/util/timings.test.ts
@@ -1,7 +1,7 @@
 import {suite} from 'uvu';
 import * as t from 'uvu/assert';
 
-import {create_stopwatch, Timings} from './time.js';
+import {create_stopwatch, Timings} from './timings.js';
 
 /* test_create_stopwatch */
 const test_create_stopwatch = suite('create_stopwatch');

--- a/src/lib/util/timings.ts
+++ b/src/lib/util/timings.ts
@@ -46,14 +46,14 @@ export class Timings<T extends string | number = string | number> {
 		}
 		return timing;
 	}
-	getAll(): IterableIterator<[T, number]> {
+	get_all(): IterableIterator<[T, number]> {
 		return this.timings.entries();
 	}
 
 	// Merges other timings into this one,
 	// adding together values with identical keys.
 	merge(timings: Timings<T>): void {
-		for (const [key, timing] of timings.getAll()) {
+		for (const [key, timing] of timings.get_all()) {
 			this.timings.set(key, (this.timings.get(key) || 0) + timing);
 		}
 	}

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -1,10 +1,10 @@
 <script>
 	import '../app.css';
-	import {provide_devmode} from '$lib/devmode';
+	import {set_devmode} from '$lib/devmode';
 	import Devmode from '$lib/Devmode.svelte';
 	import Nav from '$lib/Nav.svelte';
 
-	const devmode = provide_devmode(false);
+	const devmode = set_devmode(false);
 </script>
 
 <svelte:head>


### PR DESCRIPTION
This updates to the latest version of Gro which is now `snake_case`.

- [x] finish Gro PR https://github.com/feltcoop/gro/pull/212
- [x] finish Felt PR https://github.com/feltcoop/felt/pull/83
- [x] update Node library adapter
- [x] add Gro dev plugin system: https://github.com/feltcoop/gro/pull/223
- [x] fix library build types: https://github.com/feltcoop/gro/pull/226
- [x] fix library publishing and map `lib/` to `.`: https://github.com/feltcoop/gro/pull/227 and https://github.com/feltcoop/gro/pull/228


When this PR is finished, we'll be able to finally complete this `felt-server` PR: https://github.com/feltcoop/felt-server/pull/42