### PR TITLE
styling tweaks

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -420,6 +420,7 @@ input[type='checkbox']::before {
 	top: 0;
 	width: 100%;
 	height: 100%;
+	text-align: center;
 	display: flex;
 	align-items: center;
 	justify-content: center;

--- a/src/lib/Markup.svelte
+++ b/src/lib/Markup.svelte
@@ -11,6 +11,7 @@
 		align-items: stretch;
 	}
 	.markup :global(ul) {
+		padding: var(--spacing_rg);
 		padding-left: var(--spacing_xl);
 		list-style: disc;
 	}
@@ -18,7 +19,7 @@
 		display: list-item;
 	}
 	.markup :global(p) {
-		padding: var(--spacing_lg) 0;
+		padding: var(--spacing_rg) 0;
 	}
 	.markup :global(h1) {
 		padding-bottom: var(--spacing_lg);

--- a/src/lib/Markup.svelte
+++ b/src/lib/Markup.svelte
@@ -11,8 +11,7 @@
 		align-items: stretch;
 	}
 	.markup :global(ul) {
-		padding: var(--spacing_rg);
-		padding-left: var(--spacing_xl);
+		padding: var(--spacing_rg) 0 var(--spacing_rg) var(--spacing_xl);
 		list-style: disc;
 	}
 	.markup :global(li) {
@@ -22,6 +21,6 @@
 		padding: var(--spacing_rg) 0;
 	}
 	.markup :global(h1) {
-		padding-bottom: var(--spacing_lg);
+		padding-bottom: var(--spacing_rg) 0 var(--spacing_lg);
 	}
 </style>

--- a/src/lib/onboard/consentful/Specific.svelte
+++ b/src/lib/onboard/consentful/Specific.svelte
@@ -51,13 +51,7 @@
 </Markup>
 
 {#each spaces as space (space.name)}
-	<Checkbox
-		checked={space.selected}
-		on_change={(checked) => toggle_selected(checked, space)}
-		--overflow="hidden"
-		--font_size="var(--font_size_xl3)"
-		--text_align="center"
-	>
+	<Checkbox checked={space.selected} on_change={(checked) => toggle_selected(checked, space)}>
 		<div>
 			{space.name}
 		</div>

--- a/src/lib/onboard/unconsentful/Specific.svelte
+++ b/src/lib/onboard/unconsentful/Specific.svelte
@@ -29,13 +29,7 @@
 </Markup>
 
 {#each spaces as space (space.name)}
-	<Checkbox
-		checked={space.selected}
-		on_change={(checked) => toggle_selected(checked, space)}
-		--overflow="hidden"
-		--font_size="var(--font_size_xl3)"
-		--text_align="center"
-	>
+	<Checkbox checked={space.selected} on_change={(checked) => toggle_selected(checked, space)}>
 		{space.name}
 	</Checkbox>
 {/each}


### PR DESCRIPTION
Changes a few styles. The removed variables were no-ops, except they did change the size of the default checkbox content; if that was intentional we should change the default size in `app.css`.