### PR TITLE
revertible content

### DIFF
--- a/src/lib/onboard/consentful/Informed.svelte
+++ b/src/lib/onboard/consentful/Informed.svelte
@@ -16,7 +16,7 @@
 	</ol>
 </Markup>
 
-<button on:click={() => done()}> I accept ✓ </button>
+<button on:click={() => done()}> <Markup>I accept ✓</Markup> </button>
 
 <style>
 	li {

--- a/src/lib/onboard/consentful/Revertible.svelte
+++ b/src/lib/onboard/consentful/Revertible.svelte
@@ -11,13 +11,21 @@
 
 <Markup>
 	<p>
-		Are you sure you understand the deal? <button disabled title="TODO" class="inline">
+		Before we create your (fake) account, are you sure you understand the deal?
+		<!-- TODO maybe have this button quiz the user? -->
+		<!-- <button
+			disabled
+			title="TODO"
+			class="inline"
+		>
 			test my knowledge!
-		</button>
+		</button> -->
 	</p>
-	<button on:click={() => back()}> ← go back and learn </button>
+	<button on:click={() => back()}> <Markup>← go back and learn</Markup> </button>
 	<blockquote>🌈✨ if you don't know the deal, it's not consentful✨✨</blockquote>
-	<button on:click={() => (understood = true)} disabled={understood}> yes I understand → </button>
+	<button on:click={() => (understood = true)} disabled={understood}>
+		<Markup>yes I understand →</Markup>
+	</button>
 	{#if understood}
 		<p>
 			Here's <a
@@ -31,7 +39,7 @@
 				on:click|preventDefault={() => alert('TODO -- thank you for being interested!')}
 				>account settings</a
 			>.
-			<button class="inline" on:click={() => done()}> got it → </button>
 		</p>
+		<button on:click={() => done()}> create my account → </button>
 	{/if}
 </Markup>

--- a/src/lib/onboard/unconsentful/Informed.svelte
+++ b/src/lib/onboard/unconsentful/Informed.svelte
@@ -34,7 +34,7 @@
 			Wow you did it! You win a doggy:
 			<span class="dog">🐕</span>
 		</p>
-		<p>Now click "I acknowledge" below for more rewards :-)</p>
+		<p>Now click "I accept" below for more rewards :-)</p>
 	{/if}
 </Markup>
 
@@ -51,7 +51,7 @@
 
 <button on:click={() => done()} disabled={!enable_continue_button}>
 	<Markup>
-		I acknowledge I am legally bound to the above
+		I accept I am legally bound to the above
 		<br />
 		and my only recourse is complaining on social media
 	</Markup>

--- a/src/lib/onboard/unconsentful/Revertible.svelte
+++ b/src/lib/onboard/unconsentful/Revertible.svelte
@@ -22,15 +22,15 @@
 		</a>.
 	</p>
 	<button on:click={() => done()}>
-		<Markup><span class="text" /></Markup>
+		<Markup><span class="button-text" /></Markup>
 	</button>
 </Markup>
 
 <style>
-	.text::after {
+	.button-text::after {
 		content: 'continue →';
 	}
-	button:hover .text::after {
+	button:hover .button-text::after {
 		content: 'do I have a choice?';
 	}
 </style>

--- a/src/lib/onboard/unconsentful/Revertible.svelte
+++ b/src/lib/onboard/unconsentful/Revertible.svelte
@@ -12,12 +12,14 @@
 		👍 Great! We'll never bother you about those things again unless our lawyers make us.
 	</blockquote>
 	<p>
-		If you change your mind you can delete you account <a
+		If you change your mind you can delete you account
+		<a
 			href="/account"
 			on:click|preventDefault={() =>
 				alert('Thank you for calling support. Please hold until you give up.')}
-			>by calling support</a
-		>.
+		>
+			by calling support
+		</a>.
 	</p>
 	<button on:click={() => done()}>
 		<Markup><span class="text" /></Markup>

--- a/src/lib/onboard/unconsentful/Revertible.svelte
+++ b/src/lib/onboard/unconsentful/Revertible.svelte
@@ -12,17 +12,23 @@
 		👍 Great! We'll never bother you about those things again unless our lawyers make us.
 	</blockquote>
 	<p>
-		Just checking, you accept all of that stuff, right? Our lawyers are making us ask, you know how
-		lawyers are 🙄
+		If you change your mind you can delete you account <a
+			href="/account"
+			on:click|preventDefault={() =>
+				alert('Thank you for calling support. Please hold until you give up.')}
+			>by calling support</a
+		>.
 	</p>
-	<button on:click={() => done()} />
+	<button on:click={() => done()}>
+		<Markup><span class="text" /></Markup>
+	</button>
 </Markup>
 
 <style>
-	button::after {
-		content: 'I accept →';
+	.text::after {
+		content: 'continue →';
 	}
-	button:hover::after {
-		content: 'What choice do I have?';
+	button:hover .text::after {
+		content: 'do I have a choice?';
 	}
 </style>


### PR DESCRIPTION
Adds content for #41 to the `revertible` screen. Also tweaks both sides of `informed` a bit.