### PR TITLE
persist state and tweak some content

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -108,7 +108,7 @@
 	--active_light_bg_lightness: 80%;
 	--active_light_bg_alpha: 0.5;
 	--active_light_bg: hsla(
-		var(--selected_hue),
+		var(--active_hue),
 		var(--active_light_bg_saturation),
 		var(--active_light_bg_lightness),
 		var(--active_light_bg_alpha)

--- a/src/app.css
+++ b/src/app.css
@@ -551,6 +551,7 @@ blockquote {
 code,
 pre {
 	color: var(--text_light_color);
+	background-color: var(--tint_highlight);
 }
 
 small {

--- a/src/app.css
+++ b/src/app.css
@@ -548,10 +548,14 @@ blockquote {
 	color: var(--text_light_color);
 }
 
-code,
-pre {
+code {
 	color: var(--text_light_color);
 	background-color: var(--tint_highlight);
+	padding: 0 var(--spacing_sm);
+}
+
+pre {
+	color: var(--text_light_color);
 }
 
 small {

--- a/src/lib/onboard/Credits.svelte
+++ b/src/lib/onboard/Credits.svelte
@@ -1,4 +1,4 @@
-<h3>TODO proper credits</h3>
+<p class="todo">TODO proper credits</p>
 <p>
 	This sketch is inspired by
 	<a href="https://consentful.systems"> consentful.systems </a> ✨
@@ -7,3 +7,11 @@
 	Open source permissive code at
 	<a href="https://github.com/feltcoop/felt"> github.com/feltcoop/felt </a> 💚
 </p>
+
+<style>
+	/* TODO remove */
+	.todo {
+		font-size: var(--font_size_lg);
+		opacity: 0.4;
+	}
+</style>

--- a/src/lib/onboard/End.svelte
+++ b/src/lib/onboard/End.svelte
@@ -17,10 +17,10 @@
 		<a href="https://github.com/feltcoop/felt">on GitHub</a>
 	</blockquote>
 	<Credits />
-	<p>
-		If you'd like to explore freely, press the <code>Backtick</code> key or click this button:
+	<blockquote>
+		if you'd like to explore freely, press the <code>Backtick</code> key or click this button:
 		<button class="inline" on:click={() => ($devmode = !$devmode)}>
 			{$devmode ? 'disable' : 'enable'} devmode
 		</button>
-	</p>
+	</blockquote>
 </Markup>

--- a/src/lib/onboard/End.svelte
+++ b/src/lib/onboard/End.svelte
@@ -2,19 +2,25 @@
 	import {grin} from '$lib/icons';
 	import Markup from '$lib/Markup.svelte';
 	import Credits from './Credits.svelte';
+	import {use_devmode} from '$lib/devmode';
+
+	const devmode = use_devmode();
 </script>
 
 <Markup>
-	<h1>thanks for playing!</h1>
-	<br />
-	<span>
-		we appreciate you taking the time to go through this sketch <br />
-		we hope you learned something & had some fun in the process {grin}
-	</span>
-	<br />
-	<span
-		>if you have any questions or comments, please email us at
-		<a href="mailto:team@felt.social">team@felt.social</a> or leave a comment on the github repo</span
-	>
+	<h1>Thanks for playing!</h1>
+	<p>We appreciate you taking the time to go through this sketch.</p>
+	<p>We hope you learned something & had some fun in the process {grin}</p>
+	<blockquote>
+		if you have any questions or comments, please email us at
+		<a href="mailto:team@felt.social">team@felt.social</a> or open an issue
+		<a href="https://github.com/feltcoop/felt">on GitHub</a>
+	</blockquote>
 	<Credits />
+	<p>
+		If you'd like to explore freely, press the <code>Backtick</code> key or click this button:
+		<button class="inline" on:click={() => ($devmode = !$devmode)}>
+			{$devmode ? 'disable' : 'enable'} devmode
+		</button>
+	</p>
 </Markup>

--- a/src/lib/onboard/Onboard.svelte
+++ b/src/lib/onboard/Onboard.svelte
@@ -4,7 +4,7 @@
 	import {consent_principles} from '$lib/consent/consent';
 	import type {Consent_Type, Consent_Principle_Type} from '$lib/consent/consent';
 	import Consent_Principle_View from '$lib/consent/Consent_Principle_View.svelte';
-	import {onboard_machine, onboard_data} from './onboard';
+	import {onboard_machine, onboard_data, persist_state} from './onboard';
 	import type {Onboard_State_Name} from './onboard';
 	import Nav from './Nav.svelte';
 	import Begin from './Begin.svelte';
@@ -41,6 +41,7 @@
 	};
 
 	$: update_state($state);
+	$: persist_state($state.value as any); // TODO type -- also TODO better pattern?
 
 	// reset the local state -- TODO move to xstate
 	const update_state = (_state: typeof $state) => {

--- a/src/lib/onboard/Onboard.svelte
+++ b/src/lib/onboard/Onboard.svelte
@@ -4,7 +4,7 @@
 	import {consent_principles} from '$lib/consent/consent';
 	import type {Consent_Type, Consent_Principle_Type} from '$lib/consent/consent';
 	import Consent_Principle_View from '$lib/consent/Consent_Principle_View.svelte';
-	import {onboard_machine, onboard_data, persist_state} from './onboard';
+	import {onboard_machine, onboard_data, save_state} from './onboard';
 	import type {Onboard_State_Name} from './onboard';
 	import Nav from './Nav.svelte';
 	import Begin from './Begin.svelte';
@@ -41,7 +41,7 @@
 	};
 
 	$: update_state($state);
-	$: persist_state($state.value as any); // TODO type -- also TODO better pattern?
+	$: save_state($state.value as any); // TODO type -- also TODO better pattern?
 
 	// reset the local state -- TODO move to xstate
 	const update_state = (_state: typeof $state) => {

--- a/src/lib/onboard/consentful/Informed.svelte
+++ b/src/lib/onboard/consentful/Informed.svelte
@@ -8,7 +8,7 @@
 </script>
 
 <Markup>
-	<h1>Here are the terms of use and privacy policy for this sketch:</h1>
+	<header>Here are the terms of use and privacy policy for this sketch:</header>
 	<ol>
 		<li>this is fake</li>
 		<li>we are not collecting any data, big or little</li>

--- a/src/lib/onboard/consentful/Informed.svelte
+++ b/src/lib/onboard/consentful/Informed.svelte
@@ -8,7 +8,7 @@
 </script>
 
 <Markup>
-	<header>Here are the terms of use and privacy policy for this sketch:</header>
+	<p>Here are the terms of use and privacy policy for this sketch:</p>
 	<ol>
 		<li>this is fake</li>
 		<li>we are not collecting any data, big or little</li>
@@ -19,8 +19,11 @@
 <button on:click={() => done()}> <Markup>I accept ✓</Markup> </button>
 
 <style>
+	p {
+		font-size: var(--font_size_md);
+	}
 	li {
-		font-size: var(--font_size_lg);
+		font-size: var(--font_size_md);
 	}
 	ol {
 		list-style-position: inside;

--- a/src/lib/onboard/consentful/Unburdensome.svelte
+++ b/src/lib/onboard/consentful/Unburdensome.svelte
@@ -8,7 +8,7 @@
 </script>
 
 <Markup>
-	<h2>welcome to Felt.dev!</h2>
+	<h2>Welcome to Felt.dev!</h2>
 </Markup>
 
 <blockquote>

--- a/src/lib/onboard/onboard.ts
+++ b/src/lib/onboard/onboard.ts
@@ -31,12 +31,13 @@ const to_use_onboard_machine = () =>
 
 const INITIAL_VALUE = 'begin';
 export const ONBOARD_STATE_KEY = 'felt_onboard_state';
-const load_initial_value = (): string =>
-	(typeof localStorage !== 'undefined' && localStorage.getItem(ONBOARD_STATE_KEY)) || INITIAL_VALUE;
+const load_initial_value = (): string => {
+	if (typeof localStorage === 'undefined') return INITIAL_VALUE;
+	return localStorage.getItem(ONBOARD_STATE_KEY) || INITIAL_VALUE;
+};
 export const save_state = (value: string): void => {
-	if (typeof localStorage !== 'undefined') {
-		localStorage.setItem(ONBOARD_STATE_KEY, value);
-	}
+	if (typeof localStorage === 'undefined') return;
+	localStorage.setItem(ONBOARD_STATE_KEY, value);
 };
 
 export const onboard_machine = create_machine({

--- a/src/lib/onboard/onboard.ts
+++ b/src/lib/onboard/onboard.ts
@@ -30,7 +30,7 @@ const to_use_onboard_machine = () =>
 	useMachine<Onboard_Context, Onboard_Event, Onboard_Typestate>(null!);
 
 const INITIAL_VALUE = 'begin';
-export const ONBOARD_STATE_KEY = 'felt_onboard_state';
+const ONBOARD_STATE_KEY = 'felt_onboard_state';
 const load_initial_value = (): string => {
 	if (typeof localStorage === 'undefined') return INITIAL_VALUE;
 	return localStorage.getItem(ONBOARD_STATE_KEY) || INITIAL_VALUE;

--- a/src/lib/onboard/onboard.ts
+++ b/src/lib/onboard/onboard.ts
@@ -14,6 +14,8 @@ import Unconsentful_Specific from './unconsentful/Specific.svelte';
 import Unconsentful_Unburdensome from './unconsentful/Unburdensome.svelte';
 import type {Consent_Type} from '$lib/consent/consent';
 
+// TODO we're currently using only a fraction of the xstate functionality that we want to
+
 // TODO copypasta with src/xstate/machine.ts
 
 // TODO types
@@ -27,9 +29,18 @@ type Use_Onboard_Machine = typeof to_use_onboard_machine; // TODO this is a hack
 const to_use_onboard_machine = () =>
 	useMachine<Onboard_Context, Onboard_Event, Onboard_Typestate>(null!);
 
+export const ONBOARD_STATE_KEY = 'felt_onboard_state';
+const get_initial_value = (): string =>
+	(typeof localStorage !== 'undefined' && localStorage.getItem(ONBOARD_STATE_KEY)) || 'begin';
+export const persist_state = (value: string): void => {
+	if (typeof localStorage !== 'undefined') {
+		localStorage.setItem(ONBOARD_STATE_KEY, value);
+	}
+};
+
 export const onboard_machine = create_machine({
 	id: 'onboard',
-	initial: 'begin',
+	initial: get_initial_value(),
 	states: {
 		begin: {
 			on: {NEXT: 'voluntary'},

--- a/src/lib/onboard/onboard.ts
+++ b/src/lib/onboard/onboard.ts
@@ -30,9 +30,9 @@ const to_use_onboard_machine = () =>
 	useMachine<Onboard_Context, Onboard_Event, Onboard_Typestate>(null!);
 
 export const ONBOARD_STATE_KEY = 'felt_onboard_state';
-const get_initial_value = (): string =>
+const load_initial_value = (): string =>
 	(typeof localStorage !== 'undefined' && localStorage.getItem(ONBOARD_STATE_KEY)) || 'begin';
-export const persist_state = (value: string): void => {
+export const save_state = (value: string): void => {
 	if (typeof localStorage !== 'undefined') {
 		localStorage.setItem(ONBOARD_STATE_KEY, value);
 	}
@@ -40,7 +40,7 @@ export const persist_state = (value: string): void => {
 
 export const onboard_machine = create_machine({
 	id: 'onboard',
-	initial: get_initial_value(),
+	initial: load_initial_value(),
 	states: {
 		begin: {
 			on: {NEXT: 'voluntary'},

--- a/src/lib/onboard/onboard.ts
+++ b/src/lib/onboard/onboard.ts
@@ -30,14 +30,14 @@ const to_use_onboard_machine = () =>
 	useMachine<Onboard_Context, Onboard_Event, Onboard_Typestate>(null!);
 
 const INITIAL_VALUE = 'begin';
-const ONBOARD_STATE_KEY = 'felt_onboard_state';
+const STORAGE_KEY = 'felt_onboard_state';
 const load_initial_value = (): string => {
 	if (typeof localStorage === 'undefined') return INITIAL_VALUE;
-	return localStorage.getItem(ONBOARD_STATE_KEY) || INITIAL_VALUE;
+	return localStorage.getItem(STORAGE_KEY) || INITIAL_VALUE;
 };
 export const save_state = (value: string): void => {
 	if (typeof localStorage === 'undefined') return;
-	localStorage.setItem(ONBOARD_STATE_KEY, value);
+	localStorage.setItem(STORAGE_KEY, value);
 };
 
 export const onboard_machine = create_machine({

--- a/src/lib/onboard/onboard.ts
+++ b/src/lib/onboard/onboard.ts
@@ -29,9 +29,10 @@ type Use_Onboard_Machine = typeof to_use_onboard_machine; // TODO this is a hack
 const to_use_onboard_machine = () =>
 	useMachine<Onboard_Context, Onboard_Event, Onboard_Typestate>(null!);
 
+const INITIAL_VALUE = 'begin';
 export const ONBOARD_STATE_KEY = 'felt_onboard_state';
 const load_initial_value = (): string =>
-	(typeof localStorage !== 'undefined' && localStorage.getItem(ONBOARD_STATE_KEY)) || 'begin';
+	(typeof localStorage !== 'undefined' && localStorage.getItem(ONBOARD_STATE_KEY)) || INITIAL_VALUE;
 export const save_state = (value: string): void => {
 	if (typeof localStorage !== 'undefined') {
 		localStorage.setItem(ONBOARD_STATE_KEY, value);

--- a/src/lib/onboard/unconsentful/Specific.svelte
+++ b/src/lib/onboard/unconsentful/Specific.svelte
@@ -35,5 +35,5 @@
 {/each}
 
 <button on:click={() => done()}>
-	<Markup>Let's get to posting...</Markup>
+	<Markup>let's start posting...</Markup>
 </button>


### PR DESCRIPTION
The main change here is that your current state (which of the 7 screens) is now saved to `localStorage`, and should persist on refresh. This makes the experience much better if you click away to another link or otherwise reload.

A second important change is adding a `devmode` toggle button and descriptive line at the end screen.

This also restructures some content and makes some minor changes, like making word case more consistent in various usage. 

It also fixes the selection highlight -- turns out text selection was not broken, but I had an obsolete CSS var coloring it, so it was invisible.