### PR TITLE
fix #38: add credits and summaries of the consent principles

### DIFF
--- a/src/lib/consent/consent.ts
+++ b/src/lib/consent/consent.ts
@@ -1,10 +1,7 @@
 /*
 
-copied from: https://consentful.systems/
-
-TODO add summarys
-
-TODO should "affirmative consent" instead of "consent" in some places?
+The five principles of consent are from https://consentful.systems/
+(research led by Jane Im - https://imjane.net)
 
 */
 
@@ -31,11 +28,29 @@ export interface Consent_Principle {
 }
 
 export const consent_principles_data: Consent_Principle[] = [
-	{type: 'voluntary', summary: 'TODO'},
-	{type: 'informed', summary: 'TODO'},
-	{type: 'revertible', summary: 'TODO'},
-	{type: 'specific', summary: 'TODO'},
-	{type: 'unburdensome', summary: 'TODO'},
+	{
+		type: 'voluntary',
+		summary: 'Consent is an agreement that is 1) freely given and 2) enthusiastic.',
+	},
+	{
+		type: 'informed',
+		summary:
+			'People can only consent to an interaction after being given correct information about it—in an accessible way.',
+	},
+	{
+		type: 'revertible',
+		summary: 'Consent is an ongoing negotiation and can be revoked at any time.',
+	},
+	{
+		type: 'specific',
+		summary:
+			'People should be able to consent to a particular action (or a particular person), and not a series of actions or people.',
+	},
+	{
+		type: 'unburdensome',
+		summary:
+			'The costs associated with giving consent should not be so high that a person gives in and says "yes" when they would rather say "no."',
+	},
 ];
 
 const [voluntary, informed, revertible, specific, unburdensome] = consent_principles_data;

--- a/src/lib/onboard/Credits.svelte
+++ b/src/lib/onboard/Credits.svelte
@@ -1,7 +1,9 @@
 <p class="todo">TODO proper credits</p>
 <p>
-	This sketch is inspired by
-	<a href="https://consentful.systems"> consentful.systems </a> ✨
+	The five principles of consent are from <a href="https://consentful.systems">
+		consentful.systems
+	</a>
+	(research led by <a href="https://imjane.net"> Jane Im </a>) ✨
 </p>
 <p>
 	Open source permissive code at


### PR DESCRIPTION
This closes #38 with the descriptions of the consent principles from http://consentful.systems/ and adds proper attribution. I simplified the credits line slightly, removing some of the previous wording that distracts from the newer version.

We'll probably need to rework styling or layout a bit -- I'll keep this PR content-only.