### PR TITLE
fix #77: streamline `unconsentful:voluntary`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,8 @@
       },
       "devDependencies": {
         "@feltcoop/gro": "^0.26.2",
-        "@sveltejs/adapter-static": "^1.0.0-next.11",
-        "@sveltejs/kit": "^1.0.0-next.109",
+        "@sveltejs/adapter-static": "^1.0.0-next.13",
+        "@sveltejs/kit": "^1.0.0-next.115",
         "@xstate/svelte": "^0.1.0",
         "prettier": "~2.2.1",
         "prettier-plugin-svelte": "^2.2.0",
@@ -358,24 +358,21 @@
       }
     },
     "node_modules/@sveltejs/adapter-static": {
-      "version": "1.0.0-next.11",
-      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-1.0.0-next.11.tgz",
-      "integrity": "sha512-flqdt6nJxzRPfhYDZbvrw1iFmc87E3rLJ/Rz7K+d4or/slyqHSxH+yOmQ7CJKej5DidliuTpAOvulithuDc0yw==",
-      "dev": true,
-      "peerDependencies": {
-        "@sveltejs/kit": "1.0.0-next.109"
-      }
+      "version": "1.0.0-next.13",
+      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-1.0.0-next.13.tgz",
+      "integrity": "sha512-zaXJlWK9JfrjrE6nG5etB8kf4DSkbE3H8Ql6gmCk3WjdvpY85a60TMYBU9OK2iunkqpHnPYiMUGEnOGYmWlLYA==",
+      "dev": true
     },
     "node_modules/@sveltejs/kit": {
-      "version": "1.0.0-next.109",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.109.tgz",
-      "integrity": "sha512-72iHsgcZTj9WU2VMq/qzMdFidTrSlJ1+KE0Iiw43Gee8TkKi5tMOyeu/f8lWa4HzdHLFZ2CJdvmcL7w3F4SWjg==",
+      "version": "1.0.0-next.115",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.115.tgz",
+      "integrity": "sha512-XbkL9hI7LI0Dfum9crtBIeENqdJEjMfDaX3qQTTgdYkhlb4KNNYErmDWo8bJNJKEfdV0BJBVN/I0wiat3cd/yA==",
       "dev": true,
       "dependencies": {
-        "@sveltejs/vite-plugin-svelte": "^1.0.0-next.10",
+        "@sveltejs/vite-plugin-svelte": "^1.0.0-next.11",
         "cheap-watch": "^1.0.3",
         "sade": "^1.7.4",
-        "vite": "^2.3.1"
+        "vite": "2.3.7"
       },
       "bin": {
         "svelte-kit": "svelte-kit.js"
@@ -388,38 +385,23 @@
       }
     },
     "node_modules/@sveltejs/vite-plugin-svelte": {
-      "version": "1.0.0-next.10",
-      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.0-next.10.tgz",
-      "integrity": "sha512-ImvxbhPePm2hWNTKBSA3LHAYGwiEjHjvvgfPLXm4R87sfZ+BMXql9jBmDpzUC/URBLT4BB3Jxos/i523qkJBHg==",
+      "version": "1.0.0-next.11",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.0-next.11.tgz",
+      "integrity": "sha512-EYR1I145k5rflVqhPwk3442m3bkYimTKSHM9uO5KdomXzt+GS9ZSBJQE3/wy1Di9V8OnGa3oKpckI3OZsHkTIA==",
       "dev": true,
       "dependencies": {
         "@rollup/pluginutils": "^4.1.0",
         "chalk": "^4.1.1",
         "debug": "^4.3.2",
-        "hash-sum": "^2.0.0",
         "require-relative": "^0.8.7",
-        "slash": "^4.0.0",
-        "source-map": "^0.7.3",
-        "svelte-hmr": "^0.14.2"
+        "svelte-hmr": "^0.14.4"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": "^12.20 || ^14.13.1 || >= 16"
       },
       "peerDependencies": {
-        "svelte": "^3.37.0",
-        "vite": "^2.2.3"
-      }
-    },
-    "node_modules/@sveltejs/vite-plugin-svelte/node_modules/slash": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
-      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "svelte": "^3.38.2",
+        "vite": "^2.3.7"
       }
     },
     "node_modules/@types/estree": {
@@ -665,9 +647,9 @@
       "dev": true
     },
     "node_modules/esbuild": {
-      "version": "0.11.23",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.11.23.tgz",
-      "integrity": "sha512-iaiZZ9vUF5wJV8ob1tl+5aJTrwDczlvGP0JoMmnpC2B0ppiMCu8n8gmy5ZTGl5bcG081XBVn+U+jP+mPFm5T5Q==",
+      "version": "0.12.8",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.8.tgz",
+      "integrity": "sha512-sx/LwlP/SWTGsd9G4RlOPrXnIihAJ2xwBUmzoqe2nWwbXORMQWtAGNJNYLBJJqa3e9PWvVzxdrtyFZJcr7D87g==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -899,12 +881,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/hash-sum": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-2.0.0.tgz",
-      "integrity": "sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg==",
-      "dev": true
-    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -1032,9 +1008,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.1.22",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.22.tgz",
-      "integrity": "sha512-/2ZUaJX2ANuLtTvqTlgqBQNJoQO398KyJgZloL0PZkC0dpysjncRUPsFe3DUPzz/y3h+u7C46np8RMuvF3jsSQ==",
+      "version": "3.1.23",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
+      "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
       "dev": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
@@ -1095,14 +1071,14 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.2.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.10.tgz",
-      "integrity": "sha512-b/h7CPV7QEdrqIxtAf2j31U5ef05uBDuvoXv6L51Q4rcS1jdlXAVKJv+atCFdUXYl9dyTHGyoMzIepwowRJjFw==",
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.4.tgz",
+      "integrity": "sha512-/tZY0PXExXXnNhKv3TOvZAOUYRyuqcCbBm2c17YMDK0PlVII3K7/LKdt3ScHL+hhouddjUWi+1sKDf9xXW+8YA==",
       "dev": true,
       "dependencies": {
         "colorette": "^1.2.2",
-        "nanoid": "^3.1.22",
-        "source-map": "^0.6.1"
+        "nanoid": "^3.1.23",
+        "source-map-js": "^0.6.2"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -1110,15 +1086,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/postcss/"
-      }
-    },
-    "node_modules/postcss/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/prettier": {
@@ -1229,6 +1196,15 @@
       "dev": true,
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
+      "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/source-map-support": {
@@ -1403,13 +1379,13 @@
       }
     },
     "node_modules/vite": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.3.4.tgz",
-      "integrity": "sha512-7orxrF65+Q5n/sMCnO91S8OS0gkPJ7g+y3bLlc7CPCXVswK8to1T8YycCk9SZh+AcIc0TuN6YajWTBFS5atMNA==",
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.3.7.tgz",
+      "integrity": "sha512-Y0xRz11MPYu/EAvzN94+FsOZHbSvO6FUvHv127CyG7mV6oDoay2bw+g5y9wW3Blf8OY3chaz3nc/DcRe1IQ3Nw==",
       "dev": true,
       "dependencies": {
-        "esbuild": "^0.11.23",
-        "postcss": "^8.2.10",
+        "esbuild": "^0.12.5",
+        "postcss": "^8.3.0",
         "resolve": "^1.19.0",
         "rollup": "^2.38.5"
       },
@@ -1717,46 +1693,34 @@
       }
     },
     "@sveltejs/adapter-static": {
-      "version": "1.0.0-next.11",
-      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-1.0.0-next.11.tgz",
-      "integrity": "sha512-flqdt6nJxzRPfhYDZbvrw1iFmc87E3rLJ/Rz7K+d4or/slyqHSxH+yOmQ7CJKej5DidliuTpAOvulithuDc0yw==",
-      "dev": true,
-      "requires": {}
+      "version": "1.0.0-next.13",
+      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-1.0.0-next.13.tgz",
+      "integrity": "sha512-zaXJlWK9JfrjrE6nG5etB8kf4DSkbE3H8Ql6gmCk3WjdvpY85a60TMYBU9OK2iunkqpHnPYiMUGEnOGYmWlLYA==",
+      "dev": true
     },
     "@sveltejs/kit": {
-      "version": "1.0.0-next.109",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.109.tgz",
-      "integrity": "sha512-72iHsgcZTj9WU2VMq/qzMdFidTrSlJ1+KE0Iiw43Gee8TkKi5tMOyeu/f8lWa4HzdHLFZ2CJdvmcL7w3F4SWjg==",
+      "version": "1.0.0-next.115",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.115.tgz",
+      "integrity": "sha512-XbkL9hI7LI0Dfum9crtBIeENqdJEjMfDaX3qQTTgdYkhlb4KNNYErmDWo8bJNJKEfdV0BJBVN/I0wiat3cd/yA==",
       "dev": true,
       "requires": {
-        "@sveltejs/vite-plugin-svelte": "^1.0.0-next.10",
+        "@sveltejs/vite-plugin-svelte": "^1.0.0-next.11",
         "cheap-watch": "^1.0.3",
         "sade": "^1.7.4",
-        "vite": "^2.3.1"
+        "vite": "2.3.7"
       }
     },
     "@sveltejs/vite-plugin-svelte": {
-      "version": "1.0.0-next.10",
-      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.0-next.10.tgz",
-      "integrity": "sha512-ImvxbhPePm2hWNTKBSA3LHAYGwiEjHjvvgfPLXm4R87sfZ+BMXql9jBmDpzUC/URBLT4BB3Jxos/i523qkJBHg==",
+      "version": "1.0.0-next.11",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.0-next.11.tgz",
+      "integrity": "sha512-EYR1I145k5rflVqhPwk3442m3bkYimTKSHM9uO5KdomXzt+GS9ZSBJQE3/wy1Di9V8OnGa3oKpckI3OZsHkTIA==",
       "dev": true,
       "requires": {
         "@rollup/pluginutils": "^4.1.0",
         "chalk": "^4.1.1",
         "debug": "^4.3.2",
-        "hash-sum": "^2.0.0",
         "require-relative": "^0.8.7",
-        "slash": "^4.0.0",
-        "source-map": "^0.7.3",
-        "svelte-hmr": "^0.14.2"
-      },
-      "dependencies": {
-        "slash": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
-          "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
-          "dev": true
-        }
+        "svelte-hmr": "^0.14.4"
       }
     },
     "@types/estree": {
@@ -1949,9 +1913,9 @@
       "dev": true
     },
     "esbuild": {
-      "version": "0.11.23",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.11.23.tgz",
-      "integrity": "sha512-iaiZZ9vUF5wJV8ob1tl+5aJTrwDczlvGP0JoMmnpC2B0ppiMCu8n8gmy5ZTGl5bcG081XBVn+U+jP+mPFm5T5Q==",
+      "version": "0.12.8",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.8.tgz",
+      "integrity": "sha512-sx/LwlP/SWTGsd9G4RlOPrXnIihAJ2xwBUmzoqe2nWwbXORMQWtAGNJNYLBJJqa3e9PWvVzxdrtyFZJcr7D87g==",
       "dev": true
     },
     "esinstall": {
@@ -2129,12 +2093,6 @@
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true
     },
-    "hash-sum": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-2.0.0.tgz",
-      "integrity": "sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg==",
-      "dev": true
-    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -2242,9 +2200,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.1.22",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.22.tgz",
-      "integrity": "sha512-/2ZUaJX2ANuLtTvqTlgqBQNJoQO398KyJgZloL0PZkC0dpysjncRUPsFe3DUPzz/y3h+u7C46np8RMuvF3jsSQ==",
+      "version": "3.1.23",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
+      "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
       "dev": true
     },
     "object-assign": {
@@ -2287,22 +2245,14 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.2.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.10.tgz",
-      "integrity": "sha512-b/h7CPV7QEdrqIxtAf2j31U5ef05uBDuvoXv6L51Q4rcS1jdlXAVKJv+atCFdUXYl9dyTHGyoMzIepwowRJjFw==",
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.4.tgz",
+      "integrity": "sha512-/tZY0PXExXXnNhKv3TOvZAOUYRyuqcCbBm2c17YMDK0PlVII3K7/LKdt3ScHL+hhouddjUWi+1sKDf9xXW+8YA==",
       "dev": true,
       "requires": {
         "colorette": "^1.2.2",
-        "nanoid": "^3.1.22",
-        "source-map": "^0.6.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
+        "nanoid": "^3.1.23",
+        "source-map-js": "^0.6.2"
       }
     },
     "prettier": {
@@ -2380,6 +2330,12 @@
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
       "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+      "dev": true
+    },
+    "source-map-js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
+      "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
       "dev": true
     },
     "source-map-support": {
@@ -2516,14 +2472,14 @@
       }
     },
     "vite": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.3.4.tgz",
-      "integrity": "sha512-7orxrF65+Q5n/sMCnO91S8OS0gkPJ7g+y3bLlc7CPCXVswK8to1T8YycCk9SZh+AcIc0TuN6YajWTBFS5atMNA==",
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.3.7.tgz",
+      "integrity": "sha512-Y0xRz11MPYu/EAvzN94+FsOZHbSvO6FUvHv127CyG7mV6oDoay2bw+g5y9wW3Blf8OY3chaz3nc/DcRe1IQ3Nw==",
       "dev": true,
       "requires": {
-        "esbuild": "^0.11.23",
+        "esbuild": "^0.12.5",
         "fsevents": "~2.3.1",
-        "postcss": "^8.2.10",
+        "postcss": "^8.3.0",
         "resolve": "^1.19.0",
         "rollup": "^2.38.5"
       }

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   },
   "devDependencies": {
     "@feltcoop/gro": "^0.26.2",
-    "@sveltejs/adapter-static": "^1.0.0-next.11",
-    "@sveltejs/kit": "^1.0.0-next.109",
+    "@sveltejs/adapter-static": "^1.0.0-next.13",
+    "@sveltejs/kit": "^1.0.0-next.115",
     "@xstate/svelte": "^0.1.0",
     "prettier": "~2.2.1",
     "prettier-plugin-svelte": "^2.2.0",

--- a/src/lib/onboard/unconsentful/Unburdensome.svelte
+++ b/src/lib/onboard/unconsentful/Unburdensome.svelte
@@ -28,7 +28,7 @@
 		{id: 'who is this?', selected: true},
 		{id: '1000 spammers', selected: true},
 		{id: 'a friend with whom you will talk about this app irl', selected: true},
-		{id: 'the friend who invited me in the first place', selected: true},
+		{id: 'the friend who invited you in the first place', selected: true},
 		{id: "random stranger who typo'd my address", selected: true}, // TODO reward
 		{id: 'that guy from the thing last week', selected: true},
 		{id: 'a dog on the internet', selected: true},

--- a/src/lib/onboard/unconsentful/Unburdensome.svelte
+++ b/src/lib/onboard/unconsentful/Unburdensome.svelte
@@ -29,7 +29,7 @@
 		{id: '1000 spammers', selected: true},
 		{id: 'a friend with whom you will talk about this app irl', selected: true},
 		{id: 'the friend who invited you in the first place', selected: true},
-		{id: "random stranger who typo'd my address", selected: true}, // TODO reward
+		{id: "random stranger who typo'd your address", selected: true}, // TODO reward
 		{id: 'that guy from the thing last week', selected: true},
 		{id: 'a dog on the internet', selected: true},
 		{id: 'alice', selected: true},

--- a/src/lib/onboard/unconsentful/Unburdensome.svelte
+++ b/src/lib/onboard/unconsentful/Unburdensome.svelte
@@ -27,7 +27,7 @@
 		{id: 'your bank', selected: true},
 		{id: 'who is this?', selected: true},
 		{id: '1000 spammers', selected: true},
-		{id: 'a friend with whom i will talk about this irl', selected: true},
+		{id: 'a friend with whom you will talk about this app irl', selected: true},
 		{id: 'the friend who invited me in the first place', selected: true},
 		{id: "random stranger who typo'd my address", selected: true}, // TODO reward
 		{id: 'that guy from the thing last week', selected: true},

--- a/src/lib/onboard/unconsentful/Voluntary.svelte
+++ b/src/lib/onboard/unconsentful/Voluntary.svelte
@@ -119,72 +119,71 @@
 		{:else if create_error_message}
 			<Message text=":-)" />
 		{/if}
-		{#if !create_error_message}
-			<Message text="or ↷" />
-		{/if}
 	</div>
 
-	{#each provider_list as provider (provider.name)}
-		<button
-			type="button"
-			on:click={() => signup_with(provider)}
-			disabled={!!selected_provider && selected_provider === provider}
-			class:selected={!!selected_provider && selected_provider === provider}
-		>
-			{#if provider.name === 'TRUSTED_CO'}
-				signup with {provider.name}
-			{:else}
-				<Markup>
-					signup with {provider.name}
-				</Markup>
-			{/if}
-		</button>
-	{/each}
-
-	{#if selected_provider === providers.SOCIAL_CO || selected_provider === providers.TRACKER_CO}
-		{#if selected_provider && selected_provider !== providers.TRUSTED_CO}
-			<Help_Message text={signup_helper_message} />
-			<input
-				bind:value={phone_number}
-				bind:this={phone_number_el}
-				placeholder="your phone number"
-				on:keydown={(e) => {
-					if (e.key === 'Enter') home_address_el.focus();
-				}}
-			/>
-			<input
-				bind:value={home_address}
-				bind:this={home_address_el}
-				placeholder="your home address"
-				on:keydown={(e) => {
-					if (e.key === 'Enter') anything_else_el.focus();
-				}}
-			/>
-			<input
-				bind:value={anything_else}
-				bind:this={anything_else_el}
-				placeholder="anything else you want to share? :-)"
-				on:keydown={(e) => {
-					if (e.key === 'Enter') {
-						if (enable_signup_button) {
-							signup(data, selected_provider);
-						} else {
-							phone_number_el.focus();
-						}
-					}
-				}}
-			/>
+	{#if create_error_message}
+		{#each provider_list as provider (provider.name)}
 			<button
 				type="button"
-				on:click={() => signup(data, selected_provider)}
-				disabled={!enable_signup_button}
+				on:click={() => signup_with(provider)}
+				disabled={!!selected_provider && selected_provider === provider}
+				class:selected={!!selected_provider && selected_provider === provider}
 			>
-				call my phone<br />
-				to finish signup<br />with {selected_provider.name}
+				{#if provider.name === 'TRUSTED_CO'}
+					signup with {provider.name}
+				{:else}
+					<Markup>
+						signup with {provider.name}
+					</Markup>
+				{/if}
 			</button>
+		{/each}
+
+		{#if selected_provider === providers.SOCIAL_CO || selected_provider === providers.TRACKER_CO}
+			{#if selected_provider && selected_provider !== providers.TRUSTED_CO}
+				<Help_Message text={signup_helper_message} />
+				<input
+					bind:value={phone_number}
+					bind:this={phone_number_el}
+					placeholder="your phone number"
+					on:keydown={(e) => {
+						if (e.key === 'Enter') home_address_el.focus();
+					}}
+				/>
+				<input
+					bind:value={home_address}
+					bind:this={home_address_el}
+					placeholder="your home address"
+					on:keydown={(e) => {
+						if (e.key === 'Enter') anything_else_el.focus();
+					}}
+				/>
+				<input
+					bind:value={anything_else}
+					bind:this={anything_else_el}
+					placeholder="anything else you want to share? :-)"
+					on:keydown={(e) => {
+						if (e.key === 'Enter') {
+							if (enable_signup_button) {
+								signup(data, selected_provider);
+							} else {
+								phone_number_el.focus();
+							}
+						}
+					}}
+				/>
+				<button
+					type="button"
+					on:click={() => signup(data, selected_provider)}
+					disabled={!enable_signup_button}
+				>
+					call my phone<br />
+					to finish signup<br />with {selected_provider.name}
+				</button>
+			{/if}
+		{:else if selected_provider}
+			<Error_Message text={signup_error_message} />
 		{/if}
-	{:else if selected_provider}
-		<Error_Message text={signup_error_message} />
 	{/if}
 </form>
 

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -1,18 +1,14 @@
 <script>
-	import {page} from '$app/stores';
-
 	import '../app.css';
 	import {provide_devmode} from '$lib/devmode';
 	import Devmode from '$lib/Devmode.svelte';
 	import Nav from '$lib/Nav.svelte';
 
-	$: path = $page.path;
-
 	const devmode = provide_devmode(false);
 </script>
 
 <svelte:head>
-	<link rel="shortcut icon" href="favicon.png" />
+	<link rel="shortcut icon" href="/favicon.png" />
 </svelte:head>
 
 <nav>

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -2,7 +2,7 @@ import {typescript} from 'svelte-preprocess-esbuild';
 import staticAdapter from '@sveltejs/adapter-static';
 import {readFileSync} from 'fs';
 
-const pkg = JSON.parse(readFileSync('package.json', 'utf8'));
+const pkg = JSON.parse(readFileSync(new URL('package.json', import.meta.url), 'utf8'));
 
 /** @type {import('@sveltejs/kit').Config} */
 export default {


### PR DESCRIPTION
This makes the changes described in #77 to make the social logins appear only after a failed attempt to login with a username and password.

It also fixes the favicon link, cleans some things up, and upgrades to the latest SvelteKit.

closes #77