### PR TITLE
remove ssr config

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,8 +1,5 @@
 import {typescript} from 'svelte-preprocess-esbuild';
 import staticAdapter from '@sveltejs/adapter-static';
-import {readFileSync} from 'fs';
-
-const pkg = JSON.parse(readFileSync(new URL('package.json', import.meta.url), 'utf8'));
 
 /** @type {import('@sveltejs/kit').Config} */
 export default {
@@ -12,10 +9,5 @@ export default {
 		target: '#svelte',
 		appDir: 'app', // because the default '_app' is ignored by GitHub pages by default
 		files: {assets: 'src/static'},
-		vite: {
-			ssr: {
-				noExternal: Object.keys(pkg.dependencies || {}),
-			},
-		},
 	},
 };


### PR DESCRIPTION
Removes the obsolete Vite config from `svelte.config.js`.
