### PR TITLE
upgrade gro

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "kleur": "^4.1.4"
       },
       "devDependencies": {
-        "@feltcoop/gro": "^0.26.2",
+        "@feltcoop/gro": "^0.27.0",
         "@sveltejs/adapter-static": "^1.0.0-next.13",
         "@sveltejs/kit": "^1.0.0-next.115",
         "@xstate/svelte": "^0.1.0",
@@ -33,9 +33,9 @@
       }
     },
     "node_modules/@feltcoop/felt": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.1.3.tgz",
-      "integrity": "sha512-fYOVZZ23ZtcN2H72If4H62Ssx0E683eaTVIz7Z+dI2q23mMsdt3TrMkj2+WPHG2JCOhueYdDTTMwl8uSCeJgTg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.2.0.tgz",
+      "integrity": "sha512-cWtXGH5tbKRJlljTEmYWDppcBdnK5e7oJ2FWBCKBpkkGHTwMQy2HrTney951nxAgbmu41K7cJzDjS2WnjbuBvg==",
       "dev": true,
       "dependencies": {
         "@lukeed/uuid": "^2.0.0",
@@ -47,24 +47,20 @@
       }
     },
     "node_modules/@feltcoop/gro": {
-      "version": "0.26.2",
-      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.26.2.tgz",
-      "integrity": "sha512-LkK/aw1mlfdXNJgBMyBJGd1KTF35KEM+FKrOA1aN1pbNaP0xSZOj5TQfnkZKpBr0tBPcL0w1LsEwJkRsOI7skQ==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.27.0.tgz",
+      "integrity": "sha512-YhSi86wOOb6snz7+ARua30xwxS6+w8/lTbIZvjqbfe6Dm3SuZxzAunMPd3AstJeQaXzaAnh8l37+vB1Ia4JeoA==",
       "dev": true,
       "dependencies": {
-        "@feltcoop/felt": "^0.1.3",
+        "@feltcoop/felt": "^0.2.0",
         "@rollup/plugin-commonjs": "^18.0.0",
         "@rollup/plugin-node-resolve": "^11.2.1",
         "@rollup/pluginutils": "^4.1.0",
-        "@types/fs-extra": "^9.0.9",
-        "@types/node": "^15.6.1",
-        "@types/prettier": "^2.2.3",
         "cheap-watch": "^1.0.3",
         "es-module-lexer": "^0.4.1",
         "esbuild": "^0.9.3",
         "esinstall": "1.0.5",
         "fs-extra": "^10.0.0",
-        "locate-character": "^2.0.5",
         "mri": "^1.1.6",
         "path-browserify": "^1.0.1",
         "prettier": "^2.2.1",
@@ -77,7 +73,7 @@
         "svelte-preprocess-esbuild": "^2.0.0",
         "terser": "^5.6.1",
         "tslib": "^2.1.0",
-        "typescript": "^4.2.3",
+        "typescript": "^4.3.2",
         "uvu": "^0.5.1"
       },
       "bin": {
@@ -410,25 +406,10 @@
       "integrity": "sha512-c5ciR06jK8u9BstrmJyO97m+klJrrhCf9u3rLu3DEAJBirxRqSCvDQoYKmxuYwQI5SZChAWu+tq9oVlGRuzPAg==",
       "dev": true
     },
-    "node_modules/@types/fs-extra": {
-      "version": "9.0.11",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.11.tgz",
-      "integrity": "sha512-mZsifGG4QeQ7hlkhO56u7zt/ycBgGxSVsFI/6lGTU34VtwkiqrrSDgw0+ygs8kFGWcXnFQWMrzF2h7TtDFNixA==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/node": {
       "version": "15.6.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-15.6.1.tgz",
       "integrity": "sha512-7EIraBEyRHEe7CH+Fm1XvgqU6uwZN8Q7jppJGcqjROMT29qhAuuOxYB1uEY5UMYQKEmA5D+5tBnhdaPXSsLONA==",
-      "dev": true
-    },
-    "node_modules/@types/prettier": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.2.3.tgz",
-      "integrity": "sha512-PijRCG/K3s3w1We6ynUKdxEc5AcuuH3NBmMDP8uvKVp6X43UY7NQlTzczakXP3DJR0F4dfNQIGjU2cUeRYs2AA==",
       "dev": true
     },
     "node_modules/@types/resolve": {
@@ -953,12 +934,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/locate-character": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-2.0.5.tgz",
-      "integrity": "sha512-n2GmejDXtOPBAZdIiEFy5dJ5N38xBCXLNOtw2WpB9kGh6pnrEuKlwYI+Tkpofc4wDtVXHtoAOJaMRlYG/oYaxg==",
-      "dev": true
-    },
     "node_modules/magic-string": {
       "version": "0.25.7",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
@@ -1314,9 +1289,9 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
-      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.4.tgz",
+      "integrity": "sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -1430,9 +1405,9 @@
   },
   "dependencies": {
     "@feltcoop/felt": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.1.3.tgz",
-      "integrity": "sha512-fYOVZZ23ZtcN2H72If4H62Ssx0E683eaTVIz7Z+dI2q23mMsdt3TrMkj2+WPHG2JCOhueYdDTTMwl8uSCeJgTg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.2.0.tgz",
+      "integrity": "sha512-cWtXGH5tbKRJlljTEmYWDppcBdnK5e7oJ2FWBCKBpkkGHTwMQy2HrTney951nxAgbmu41K7cJzDjS2WnjbuBvg==",
       "dev": true,
       "requires": {
         "@lukeed/uuid": "^2.0.0",
@@ -1441,24 +1416,20 @@
       }
     },
     "@feltcoop/gro": {
-      "version": "0.26.2",
-      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.26.2.tgz",
-      "integrity": "sha512-LkK/aw1mlfdXNJgBMyBJGd1KTF35KEM+FKrOA1aN1pbNaP0xSZOj5TQfnkZKpBr0tBPcL0w1LsEwJkRsOI7skQ==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.27.0.tgz",
+      "integrity": "sha512-YhSi86wOOb6snz7+ARua30xwxS6+w8/lTbIZvjqbfe6Dm3SuZxzAunMPd3AstJeQaXzaAnh8l37+vB1Ia4JeoA==",
       "dev": true,
       "requires": {
-        "@feltcoop/felt": "^0.1.3",
+        "@feltcoop/felt": "^0.2.0",
         "@rollup/plugin-commonjs": "^18.0.0",
         "@rollup/plugin-node-resolve": "^11.2.1",
         "@rollup/pluginutils": "^4.1.0",
-        "@types/fs-extra": "^9.0.9",
-        "@types/node": "^15.6.1",
-        "@types/prettier": "^2.2.3",
         "cheap-watch": "^1.0.3",
         "es-module-lexer": "^0.4.1",
         "esbuild": "^0.9.3",
         "esinstall": "1.0.5",
         "fs-extra": "^10.0.0",
-        "locate-character": "^2.0.5",
         "mri": "^1.1.6",
         "path-browserify": "^1.0.1",
         "prettier": "^2.2.1",
@@ -1471,7 +1442,7 @@
         "svelte-preprocess-esbuild": "^2.0.0",
         "terser": "^5.6.1",
         "tslib": "^2.1.0",
-        "typescript": "^4.2.3",
+        "typescript": "^4.3.2",
         "uvu": "^0.5.1"
       },
       "dependencies": {
@@ -1729,25 +1700,10 @@
       "integrity": "sha512-c5ciR06jK8u9BstrmJyO97m+klJrrhCf9u3rLu3DEAJBirxRqSCvDQoYKmxuYwQI5SZChAWu+tq9oVlGRuzPAg==",
       "dev": true
     },
-    "@types/fs-extra": {
-      "version": "9.0.11",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.11.tgz",
-      "integrity": "sha512-mZsifGG4QeQ7hlkhO56u7zt/ycBgGxSVsFI/6lGTU34VtwkiqrrSDgw0+ygs8kFGWcXnFQWMrzF2h7TtDFNixA==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/node": {
       "version": "15.6.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-15.6.1.tgz",
       "integrity": "sha512-7EIraBEyRHEe7CH+Fm1XvgqU6uwZN8Q7jppJGcqjROMT29qhAuuOxYB1uEY5UMYQKEmA5D+5tBnhdaPXSsLONA==",
-      "dev": true
-    },
-    "@types/prettier": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.2.3.tgz",
-      "integrity": "sha512-PijRCG/K3s3w1We6ynUKdxEc5AcuuH3NBmMDP8uvKVp6X43UY7NQlTzczakXP3DJR0F4dfNQIGjU2cUeRYs2AA==",
       "dev": true
     },
     "@types/resolve": {
@@ -2157,12 +2113,6 @@
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
       "integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA=="
     },
-    "locate-character": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-2.0.5.tgz",
-      "integrity": "sha512-n2GmejDXtOPBAZdIiEFy5dJ5N38xBCXLNOtw2WpB9kGh6pnrEuKlwYI+Tkpofc4wDtVXHtoAOJaMRlYG/oYaxg==",
-      "dev": true
-    },
     "magic-string": {
       "version": "0.25.7",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
@@ -2421,9 +2371,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
-      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.4.tgz",
+      "integrity": "sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==",
       "dev": true
     },
     "universalify": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "gro test"
   },
   "devDependencies": {
-    "@feltcoop/gro": "^0.26.2",
+    "@feltcoop/gro": "^0.27.0",
     "@sveltejs/adapter-static": "^1.0.0-next.13",
     "@sveltejs/kit": "^1.0.0-next.115",
     "@xstate/svelte": "^0.1.0",

--- a/src/gro.config.ts
+++ b/src/gro.config.ts
@@ -1,4 +1,4 @@
-import type {GroConfigCreator, GroConfigPartial} from '@feltcoop/gro';
+import type {Gro_Config_Creator, Gro_Config_Partial} from '@feltcoop/gro';
 
 const files = [
 	// top level API: `import {...} from '@feltcoop/felt';`
@@ -29,13 +29,13 @@ const files = [
 	'lib/util/uuid.ts',
 ];
 
-export const config: GroConfigCreator = async () => {
-	const partial: GroConfigPartial = {
+export const config: Gro_Config_Creator = async () => {
+	const partial: Gro_Config_Partial = {
 		builds: [{name: 'library', platform: 'node', input: files}],
 		adapt: async () => [
 			// TODO this is bugged in Gro, could be hackfixed with a simple in-between adapter but w/e --
 			// for now to publish Felt to npm, these two lines need to be swapped
-			(await import('@feltcoop/gro/dist/adapt/gro-adapter-sveltekit-frontend.js')).createAdapter(),
+			(await import('@feltcoop/gro/dist/adapt/gro-adapter-sveltekit-frontend.js')).create_adapter(),
 			// (await import('@feltcoop/gro/dist/adapt/gro-adapter-node-library.js')).createAdapter(),
 		],
 	};


### PR DESCRIPTION
This upgrades Gro to 0.27, which reworks a lot of internals and has some breaking changes, including [the switch to `snake_case`](https://github.com/feltcoop/gro/pull/210).