### PR TITLE
upgrade gro patch version

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # changelog
 
+## 0.3.1
+
+- upgrade Gro to 0.28.2
+  ([#63](https://github.com/feltcoop/felt/pull/63))
+
 ## 0.3.0
 
 - **break**: swap the names of `spawn` and `spawn_process`
@@ -11,7 +16,7 @@
   ([#63](https://github.com/feltcoop/felt/pull/63))
 - **break**: rename `Timings.get_all` from `Timings.getAll`
   ([#63](https://github.com/feltcoop/felt/pull/63))
-- upgrade Gro to 0.28.0
+- upgrade Gro to 0.28.1
   ([#63](https://github.com/feltcoop/felt/pull/63))
 
 ## 0.2.2

--- a/changelog.md
+++ b/changelog.md
@@ -3,7 +3,7 @@
 ## 0.3.1
 
 - upgrade Gro to 0.28.2
-  ([#63](https://github.com/feltcoop/felt/pull/63))
+  ([#87](https://github.com/feltcoop/felt/pull/87))
 
 ## 0.3.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "kleur": "^4.1.4"
       },
       "devDependencies": {
-        "@feltcoop/gro": "^0.28.1",
+        "@feltcoop/gro": "^0.28.2",
         "@sveltejs/adapter-static": "^1.0.0-next.13",
         "@sveltejs/kit": "^1.0.0-next.115",
         "@xstate/svelte": "^0.1.0",
@@ -33,9 +33,9 @@
       }
     },
     "node_modules/@feltcoop/felt": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.2.2.tgz",
-      "integrity": "sha512-t+pVEW5JgtmtJGebZAqZzYk4wz2xHGz5Ki4oaqOBHE1wJsR5VeFqcx5zt9DA7TUCgdedrBlu2g2TAo2wvHmX2g==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.3.0.tgz",
+      "integrity": "sha512-Iqm4lj0kpK433A569me3mtLkYW4s3YDSdIh9srd8WyeRW2XOaxhj7uCQ5Ozw7VG6QYQ2PTiRtM78DSP9GrQwzg==",
       "dev": true,
       "dependencies": {
         "@lukeed/uuid": "^2.0.0",
@@ -47,12 +47,12 @@
       }
     },
     "node_modules/@feltcoop/gro": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.28.1.tgz",
-      "integrity": "sha512-v/WAQ/9twdk+bA/7KaIXXSpdPsozvn7F7ocdS8hxUzAsFR1oUKiP0HxgWmONvVvxHzHSM3ZQHjwkuS2m8CGY/g==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.28.2.tgz",
+      "integrity": "sha512-VOhsd4IfAim5HcOPiY5oa2yaEntS5BBDrTXU9dXoSSOoiX089AdpIdEBH0NEOtYFbtVyYQ9Daz+U8ViEzUeLTA==",
       "dev": true,
       "dependencies": {
-        "@feltcoop/felt": "^0.2.2",
+        "@feltcoop/felt": "^0.3.0",
         "@rollup/plugin-commonjs": "^18.0.0",
         "@rollup/plugin-node-resolve": "^11.2.1",
         "@rollup/pluginutils": "^4.1.0",
@@ -1405,9 +1405,9 @@
   },
   "dependencies": {
     "@feltcoop/felt": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.2.2.tgz",
-      "integrity": "sha512-t+pVEW5JgtmtJGebZAqZzYk4wz2xHGz5Ki4oaqOBHE1wJsR5VeFqcx5zt9DA7TUCgdedrBlu2g2TAo2wvHmX2g==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.3.0.tgz",
+      "integrity": "sha512-Iqm4lj0kpK433A569me3mtLkYW4s3YDSdIh9srd8WyeRW2XOaxhj7uCQ5Ozw7VG6QYQ2PTiRtM78DSP9GrQwzg==",
       "dev": true,
       "requires": {
         "@lukeed/uuid": "^2.0.0",
@@ -1416,12 +1416,12 @@
       }
     },
     "@feltcoop/gro": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.28.1.tgz",
-      "integrity": "sha512-v/WAQ/9twdk+bA/7KaIXXSpdPsozvn7F7ocdS8hxUzAsFR1oUKiP0HxgWmONvVvxHzHSM3ZQHjwkuS2m8CGY/g==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.28.2.tgz",
+      "integrity": "sha512-VOhsd4IfAim5HcOPiY5oa2yaEntS5BBDrTXU9dXoSSOoiX089AdpIdEBH0NEOtYFbtVyYQ9Daz+U8ViEzUeLTA==",
       "dev": true,
       "requires": {
-        "@feltcoop/felt": "^0.2.2",
+        "@feltcoop/felt": "^0.3.0",
         "@rollup/plugin-commonjs": "^18.0.0",
         "@rollup/plugin-node-resolve": "^11.2.1",
         "@rollup/pluginutils": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "gro test"
   },
   "devDependencies": {
-    "@feltcoop/gro": "^0.28.1",
+    "@feltcoop/gro": "^0.28.2",
     "@sveltejs/adapter-static": "^1.0.0-next.13",
     "@sveltejs/kit": "^1.0.0-next.115",
     "@xstate/svelte": "^0.1.0",


### PR DESCRIPTION
Upgrades the patch version of Gro to 0.28.2 which uses the latest minor version of Felt. Shouldn't change anything, but ensures the mutual dependencies are playing well together.