### PR TITLE
export async helpers from root

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # changelog
 
+## 0.4.1
+
+- export `Async_Status` and `wait` from root
+  ([#89](https://github.com/feltcoop/felt/pull/89))
+
 ## 0.4.0
 
 - **break**: remove camelCase terminal color exports and rename `color_bg` from `bg_color`

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "kleur": "^4.1.4"
       },
       "devDependencies": {
-        "@feltcoop/gro": "^0.28.3",
+        "@feltcoop/gro": "^0.29.0",
         "@sveltejs/adapter-static": "^1.0.0-next.13",
         "@sveltejs/kit": "^1.0.0-next.120",
         "@xstate/svelte": "^0.1.0",
@@ -32,9 +32,9 @@
       }
     },
     "node_modules/@feltcoop/felt": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.3.0.tgz",
-      "integrity": "sha512-Iqm4lj0kpK433A569me3mtLkYW4s3YDSdIh9srd8WyeRW2XOaxhj7uCQ5Ozw7VG6QYQ2PTiRtM78DSP9GrQwzg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.4.0.tgz",
+      "integrity": "sha512-H31Lamf3lDuo+lL1z1g4MOJfrPDHJqDhvQ7ef5CdLWnA1Qq9FvlJQZEhg8/teIRgdPH27HI4PpM3s4Ichdty4Q==",
       "dev": true,
       "dependencies": {
         "@lukeed/uuid": "^2.0.0",
@@ -46,12 +46,12 @@
       }
     },
     "node_modules/@feltcoop/gro": {
-      "version": "0.28.3",
-      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.28.3.tgz",
-      "integrity": "sha512-nNRMJF5YL17uiRts12DnA0sHBMBXe3hWqhXgaIXDTAa6gJnhsWomrEdiic2P6vSkgWEfEKfglV7glU14nXJWbg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.29.0.tgz",
+      "integrity": "sha512-uytXnZ1xPGrR2c410vJEo3xYqbxHf7cdcFE32dZl8+oZNHUJo9OaTcDrEhZPIY3DwdesB3NIKjDXXR3EnRcTVA==",
       "dev": true,
       "dependencies": {
-        "@feltcoop/felt": "^0.3.0",
+        "@feltcoop/felt": "^0.4.0",
         "@rollup/plugin-commonjs": "^18.0.0",
         "@rollup/plugin-node-resolve": "^11.2.1",
         "@rollup/pluginutils": "^4.1.0",
@@ -62,17 +62,17 @@
         "fs-extra": "^10.0.0",
         "mri": "^1.1.6",
         "path-browserify": "^1.0.1",
-        "prettier": "^2.2.1",
-        "prettier-plugin-svelte": "^2.2.0",
-        "rollup": "^2.37.1",
+        "prettier": "^2.3.2",
+        "prettier-plugin-svelte": "^2.3.1",
+        "rollup": "^2.52.7",
         "source-map-support": "^0.5.19",
         "sourcemap-codec": "^1.4.8",
         "strict-event-emitter-types": "^2.0.0",
-        "svelte": "^3.37.0",
+        "svelte": "^3.38.3",
         "svelte-preprocess-esbuild": "^2.0.0",
         "terser": "^5.6.1",
-        "tslib": "^2.1.0",
-        "typescript": "^4.3.2",
+        "tslib": "^2.3.0",
+        "typescript": "^4.3.5",
         "uvu": "^0.5.1"
       },
       "bin": {
@@ -1119,9 +1119,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.45.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.45.2.tgz",
-      "integrity": "sha512-kRRU7wXzFHUzBIv0GfoFFIN3m9oteY4uAsKllIpQDId5cfnkWF2J130l+27dzDju0E6MScKiV0ZM5Bw8m4blYQ==",
+      "version": "2.52.7",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.52.7.tgz",
+      "integrity": "sha512-55cSH4CCU6MaPr9TAOyrIC+7qFCHscL7tkNsm1MBfIJRRqRbCEY0mmeFn4Wg8FKsHtEH8r389Fz38r/o+kgXLg==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -1130,7 +1130,7 @@
         "node": ">=10.0.0"
       },
       "optionalDependencies": {
-        "fsevents": "~2.3.1"
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/rollup-plugin-polyfill-node": {
@@ -1404,9 +1404,9 @@
   },
   "dependencies": {
     "@feltcoop/felt": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.3.0.tgz",
-      "integrity": "sha512-Iqm4lj0kpK433A569me3mtLkYW4s3YDSdIh9srd8WyeRW2XOaxhj7uCQ5Ozw7VG6QYQ2PTiRtM78DSP9GrQwzg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.4.0.tgz",
+      "integrity": "sha512-H31Lamf3lDuo+lL1z1g4MOJfrPDHJqDhvQ7ef5CdLWnA1Qq9FvlJQZEhg8/teIRgdPH27HI4PpM3s4Ichdty4Q==",
       "dev": true,
       "requires": {
         "@lukeed/uuid": "^2.0.0",
@@ -1415,12 +1415,12 @@
       }
     },
     "@feltcoop/gro": {
-      "version": "0.28.3",
-      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.28.3.tgz",
-      "integrity": "sha512-nNRMJF5YL17uiRts12DnA0sHBMBXe3hWqhXgaIXDTAa6gJnhsWomrEdiic2P6vSkgWEfEKfglV7glU14nXJWbg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.29.0.tgz",
+      "integrity": "sha512-uytXnZ1xPGrR2c410vJEo3xYqbxHf7cdcFE32dZl8+oZNHUJo9OaTcDrEhZPIY3DwdesB3NIKjDXXR3EnRcTVA==",
       "dev": true,
       "requires": {
-        "@feltcoop/felt": "^0.3.0",
+        "@feltcoop/felt": "^0.4.0",
         "@rollup/plugin-commonjs": "^18.0.0",
         "@rollup/plugin-node-resolve": "^11.2.1",
         "@rollup/pluginutils": "^4.1.0",
@@ -1431,17 +1431,17 @@
         "fs-extra": "^10.0.0",
         "mri": "^1.1.6",
         "path-browserify": "^1.0.1",
-        "prettier": "^2.2.1",
-        "prettier-plugin-svelte": "^2.2.0",
-        "rollup": "^2.37.1",
+        "prettier": "^2.3.2",
+        "prettier-plugin-svelte": "^2.3.1",
+        "rollup": "^2.52.7",
         "source-map-support": "^0.5.19",
         "sourcemap-codec": "^1.4.8",
         "strict-event-emitter-types": "^2.0.0",
-        "svelte": "^3.37.0",
+        "svelte": "^3.38.3",
         "svelte-preprocess-esbuild": "^2.0.0",
         "terser": "^5.6.1",
-        "tslib": "^2.1.0",
-        "typescript": "^4.3.2",
+        "tslib": "^2.3.0",
+        "typescript": "^4.3.5",
         "uvu": "^0.5.1"
       },
       "dependencies": {
@@ -2243,12 +2243,12 @@
       }
     },
     "rollup": {
-      "version": "2.45.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.45.2.tgz",
-      "integrity": "sha512-kRRU7wXzFHUzBIv0GfoFFIN3m9oteY4uAsKllIpQDId5cfnkWF2J130l+27dzDju0E6MScKiV0ZM5Bw8m4blYQ==",
+      "version": "2.52.7",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.52.7.tgz",
+      "integrity": "sha512-55cSH4CCU6MaPr9TAOyrIC+7qFCHscL7tkNsm1MBfIJRRqRbCEY0mmeFn4Wg8FKsHtEH8r389Fz38r/o+kgXLg==",
       "dev": true,
       "requires": {
-        "fsevents": "~2.3.1"
+        "fsevents": "~2.3.2"
       }
     },
     "rollup-plugin-polyfill-node": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "kleur": "^4.1.4"
   },
   "devDependencies": {
-    "@feltcoop/gro": "^0.28.3",
+    "@feltcoop/gro": "^0.29.0",
     "@sveltejs/adapter-static": "^1.0.0-next.13",
     "@sveltejs/kit": "^1.0.0-next.120",
     "@xstate/svelte": "^0.1.0",

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -3,12 +3,13 @@
 export * as icons from './icons.js';
 export * from './util/types.js';
 
+export type {Async_Status} from './util/async.js';
+export {wait} from './util/async.js';
+
 // TODO consider what top-level public API makes sense -
 // for now we're preferring deep imports to specific modules -
 // these are Gro's old exports:
 // // utils
-// export type {Async_Status} from './util/async.js';
-// export {wait, wrap} from './util/async.js';
 // export type {Spawned_Process, Spawn_Result} from './util/process.js';
 // export type {Lazy} from './util/function.js';
 // export {Unreachable_Error} from './util/error.js';

--- a/src/lib/util/async.ts
+++ b/src/lib/util/async.ts
@@ -1,6 +1,7 @@
 export type Async_Status = 'initial' | 'pending' | 'success' | 'failure';
 
-export const wait = (duration = 0) => new Promise<void>((resolve) => setTimeout(resolve, duration));
+export const wait = (duration: number = 0): Promise<void> =>
+	new Promise((resolve) => setTimeout(resolve, duration));
 
 interface Wrap_After {
 	(cb: Wrap_After_Callback): void;


### PR DESCRIPTION
Exports `Async_Status` and `wait` from the root, so they're available when importing from `@feltcoop/felt` directly, instead of needing to specify the full path at `@feltcoop/felt/util/async.js`. These are heavily used -- I don't know what we want to export at the top level, so I'm starting slowly, and these are obvious choices.

Another option is having minimal top-level exports, possibly removing the rather meaningless `util/` namespacing.

Also updates to the latest version of Gro.