### PR TITLE
Fixed wording of messages shown on the Voluntary page 

### DIFF
--- a/src/lib/sketch/onboard/consentful/Voluntary.svelte
+++ b/src/lib/sketch/onboard/consentful/Voluntary.svelte
@@ -16,7 +16,7 @@
 </script>
 
 <Markup>
-	<Message>this is not real</Message>
+	<Message>this is not a real sign-up</Message>
 	<form>
 		<input bind:value={username} placeholder="username" />
 		<input type="password" bind:value={password} placeholder="password" />

--- a/src/lib/sketch/onboard/unconsentful/Voluntary.svelte
+++ b/src/lib/sketch/onboard/unconsentful/Voluntary.svelte
@@ -112,7 +112,7 @@
 </script>
 
 <Markup>
-	<Message>this is fake</Message>
+	<Message>this is a fake sign-up</Message>
 	<form>
 		<input
 			bind:value={username}


### PR DESCRIPTION
I started making the changes I proposed. This one is a simple fix of the wording on the Voluntary page, for both consentful and unconsentful versions: this is fake --> this is a fake sign-up / this is not real --> this is not a real sign-up

It'll take me some time to change the emoji (as I'm still getting used to the code :)), so I decided to make this pull request first. Please let me know if I need to follow any convention or rules!