### PR TITLE
Changed the emoji used in the voluntary page

### DIFF
--- a/src/lib/sketch/onboard/consentful/Voluntary.svelte
+++ b/src/lib/sketch/onboard/consentful/Voluntary.svelte
@@ -16,7 +16,7 @@
 </script>
 
 <Markup>
-	<Message>this is not a real sign-up</Message>
+	<Message status="inform">this is not a real sign-up</Message>
 	<form>
 		<input bind:value={username} placeholder="username" />
 		<input type="password" bind:value={password} placeholder="password" />

--- a/src/lib/sketch/onboard/unconsentful/Voluntary.svelte
+++ b/src/lib/sketch/onboard/unconsentful/Voluntary.svelte
@@ -112,7 +112,7 @@
 </script>
 
 <Markup>
-	<Message>this is a fake sign-up</Message>
+	<Message status="inform">this is a fake sign-up</Message>
 	<form>
 		<input
 			bind:value={username}

--- a/src/lib/ui/icons.ts
+++ b/src/lib/ui/icons.ts
@@ -94,6 +94,7 @@ export const bus = '🚌';
 export const car = '🚗';
 export const ship = '🚢';
 export const rocket = '🚀';
+export const sparkle = '✨';
 
 export const arrow_left = '←';
 export const arrow_right = '→';

--- a/src/lib/ui/message.ts
+++ b/src/lib/ui/message.ts
@@ -11,5 +11,5 @@ export const message_status_options: Record<MessageStatus, MessageStatusOptions>
 	normal: {color: 'var(--text_color_light)', icon: hand_thumbs_up},
 	help: {color: 'var(--help_color)', icon: hand_point_right},
 	error: {color: 'var(--error_color)', icon: hand_facing_forward},
-	inform: {color: 'var(--text_color_light)', icon: sparkle}
+	inform: {color: 'var(--text_color_light)', icon: sparkle},
 };

--- a/src/lib/ui/message.ts
+++ b/src/lib/ui/message.ts
@@ -1,6 +1,6 @@
-import {hand_point_right, hand_thumbs_up, hand_facing_forward} from '$lib/ui/icons';
+import {hand_point_right, hand_thumbs_up, hand_facing_forward, sparkle} from '$lib/ui/icons';
 
-export type MessageStatus = 'normal' | 'help' | 'error';
+export type MessageStatus = 'normal' | 'help' | 'error' | 'inform';
 
 export interface MessageStatusOptions {
 	color: null | string;
@@ -11,4 +11,5 @@ export const message_status_options: Record<MessageStatus, MessageStatusOptions>
 	normal: {color: 'var(--text_color_light)', icon: hand_thumbs_up},
 	help: {color: 'var(--help_color)', icon: hand_point_right},
 	error: {color: 'var(--error_color)', icon: hand_facing_forward},
+	inform: {color: 'var(--text_color_light)', icon: sparkle}
 };


### PR DESCRIPTION
Changed the emoji used in the voluntary consentful and unconsentful pages to ✨. Added a new status to Message called "inform" for this. Might end up changing the emoji to something else if people find it confusing.

# Pull Request 💚-🐑👁️

In order to help us easily visualize & review components, please consider putting a [Svelte REPL](https://svelte.dev/repl) example below:
<REPL link goes here>
